### PR TITLE
examples rename task_rng to thread_rng

### DIFF
--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -546,7 +546,7 @@ fn main() {
     let (res_buffer, texture_frame, _)  = create_res_buffer(w as u16, h as u16, &mut device, texture_depth);
 
     let noise = {
-        let rand_seed = std::rand::task_rng().gen();
+        let rand_seed = std::rand::thread_rng().gen();
         Perlin::new().seed(rand_seed).octaves(4).quality(Quality::Best)
     };
 

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -167,7 +167,7 @@ fn main() {
 
     let mut device = gfx::GlDevice::new(|s| window.get_proc_address(s));
 
-    let rand_seed = std::rand::task_rng().gen();
+    let rand_seed = std::rand::thread_rng().gen();
     let noise = Perlin::new().seed(rand_seed);
     let plane = Plane::subdivide(256, 256);
     let vertex_data: Vec<Vertex> = plane.shared_vertex_iter()


### PR DESCRIPTION
to conform with 

https://github.com/rust-lang/rust/commit/1e89bbcb67020892bc0af5af218c35f0fd453fa4