### PR TITLE
Update to latest Rust nightly (WIP)

### DIFF
--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
-
 extern crate cgmath;
 extern crate gfx;
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 extern crate glfw;
 

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -26,11 +26,9 @@
 //
 // Press 1-4 to show the immediate buffers. Press 0 to show the final result.
 
-#![feature(phase)]
-
 extern crate cgmath;
 extern crate gfx;
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 extern crate glfw;
 extern crate time;

--- a/examples/glutin/main.rs
+++ b/examples/glutin/main.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
-
 //! Demonstrates how to initialize gfx-rs using the gl-init-rs library.
 
 extern crate gfx;
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 extern crate glutin;
 

--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
-#![feature(globs)]
-
 extern crate cgmath;
 extern crate gfx;
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 extern crate glfw;
 extern crate time;

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
-
 extern crate cgmath;
 extern crate gfx;
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 extern crate glfw;
 extern crate time;

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
 
 extern crate gfx;
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 extern crate glfw;
 

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase, unsafe_destructor, associated_types)]
+#![feature(unsafe_destructor)]
 #![deny(missing_docs)]
 #![deny(missing_copy_implementations)]
 
 //! Graphics device. Not meant for direct use.
 
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 extern crate libc;
 
 // TODO: Remove these exports once `gl_device` becomes a separate crate.

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
-
 //! An efficient, low-level, bindless graphics API for Rust. See [the
 //! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
 
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 extern crate libc;
 
 extern crate device;

--- a/src/gfx_macros/lib.rs
+++ b/src/gfx_macros/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(macro_rules, plugin_registrar, quote)]
+#![feature(plugin_registrar, quote)]
 #![deny(missing_copy_implementations)]
 
 //! Macro extensions crate.
@@ -75,9 +75,9 @@ static EXTERN_CRATE_HACK: &'static str = "__gfx_extern_crate_hack";
 
 /// Inserts a module with a unique identifier that reexports
 /// The `gfx` crate, and returns that identifier
-fn extern_crate_hack(context: &mut ext::base::ExtCtxt,
+fn extern_crate_hack<PF>(context: &mut ext::base::ExtCtxt,
                      span: codemap::Span,
-                     push: |P<ast::Item>|) -> ast::Ident {
+                     mut push: PF) -> ast::Ident where PF: FnMut(P<ast::Item>) {
     let extern_crate_hack = token::gensym_ident(EXTERN_CRATE_HACK);
     // mod $EXTERN_CRATE_HACK {
     //     extern crate gfx_ = "gfx";

--- a/src/gfx_macros/shader_param.rs
+++ b/src/gfx_macros/shader_param.rs
@@ -82,7 +82,7 @@ fn method_create(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
                     },
                 }
             ).collect();
-            let gen_arms = |ptype: Param, var: ast::Ident| -> Vec<ast::Arm> {
+            let gen_arms = |&: ptype: Param, var: ast::Ident| -> Vec<ast::Arm> {
                 class_info.iter().zip(fields.iter())
                           .filter(|&(&(ref class, _), _)| *class == ptype)
                           .map(|(&(_, ref name_expr), &(fname, fspan))|
@@ -255,7 +255,7 @@ impl ItemDecorator for ShaderParam {
               meta_item: &ast::MetaItem, item: &ast::Item,
               mut push: Box<FnMut(P<ast::Item>)>) {
         // Insert the `gfx` reexport module
-        let path_root = super::extern_crate_hack(context, span, |i| (*push)(i));
+        let path_root = super::extern_crate_hack(context, span, |&mut: i| (*push)(i));
 
         // constructing the Link struct
         let (base_def, link_def) = match item.node {
@@ -394,7 +394,7 @@ impl ItemDecorator for ShaderParam {
                         },
                     ),
                     attributes: Vec::new(),
-                    combine_substructure: generic::combine_substructure(|cx, span, sub|
+                    combine_substructure: generic::combine_substructure(box |cx, span, sub|
                         method_create(cx, span, sub, link_name.as_slice(), path_root)
                     ),
                 },
@@ -415,7 +415,7 @@ impl ItemDecorator for ShaderParam {
                     ],
                     ret_ty: generic::ty::Tuple(Vec::new()),
                     attributes: Vec::new(),
-                    combine_substructure: generic::combine_substructure(|cx, span, sub|
+                    combine_substructure: generic::combine_substructure(box |cx, span, sub|
                         method_fill(cx, span, sub, base_def.clone(), path_root)
                     ),
                 },

--- a/src/gfx_macros/vertex_format.rs
+++ b/src/gfx_macros/vertex_format.rs
@@ -281,7 +281,7 @@ impl ItemDecorator for VertexFormat {
                     attributes: Vec::new(),
                     // generate the method body
                     combine_substructure: generic::combine_substructure(
-                        |c, s, ss| method_body(c, s, ss, path_root)),
+                        box |c, s, ss| method_body(c, s, ss, path_root)),
                 },
             ],
         }.expand(context, meta_item, item, fixup);

--- a/src/gl_device/lib.rs
+++ b/src/gl_device/lib.rs
@@ -141,7 +141,7 @@ pub struct GlDevice {
 
 impl GlDevice {
     /// Load OpenGL symbols and detect driver information
-    pub fn new(fn_proc: |&str| -> *const ::libc::c_void) -> GlDevice {
+    pub fn new<F>(fn_proc: F) -> GlDevice where F: Fn(&str) -> *const ::libc::c_void {
         let gl = gl::Gl::load_with(fn_proc);
 
         let (info, caps) = info::get(&gl);
@@ -164,7 +164,7 @@ impl GlDevice {
 
     /// Access the OpenGL directly via a closure. OpenGL types and enumerations
     /// can be found in the `gl` crate.
-    pub unsafe fn with_gl(&mut self, fun: |&gl::Gl|) {
+    pub unsafe fn with_gl<F>(&mut self, fun: F) where F: FnOnce(&gl::Gl) {
         self.reset_state();
         fun(&self.gl);
     }

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -15,9 +15,8 @@
 //! High-level, platform independent, bindless rendering API.
 
 #![deny(missing_docs)]
-#![feature(macro_rules, phase, associated_types)]
 
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 extern crate device;
 
 use std::mem;

--- a/tests/shader_param.rs
+++ b/tests/shader_param.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
+#![feature(plugin)]
 
-#[phase(plugin)]
+#[plugin]
 extern crate gfx_macros;
 
 mod secret_lib;
@@ -42,6 +42,6 @@ struct TestParam2 {
 #[test]
 fn test_shader_param() {
     // testing if the types are visible
-    let _ref: |&TestRefBatch|;
-    let _owned: |&TestOwnedBatch|;
+    let _ref: TestRefBatch;
+    let _owned: TestOwnedBatch;
 }

--- a/tests/shaders_macro.rs
+++ b/tests/shaders_macro.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
-
-#[phase(plugin)]
+#[macro_use]
 extern crate gfx_macros;
 
 use secret_lib::gfx::ShaderSource;

--- a/tests/vertex_format.rs
+++ b/tests/vertex_format.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(phase)]
+#![feature(plugin)]
 
-#[phase(plugin)]
+#[plugin]
 extern crate gfx_macros;
 
 mod secret_lib;


### PR DESCRIPTION
Fixes a lot of breakages to do with changes to C string handling and the switch to unboxed closures. It's WIP because it compiles on the changed files but it doesn't completely fix the repo. 

The problem I'm stuck on is the `extern crate` hack in `gfx_macros`. I can't figure out how to fix it. It looks like the macro parsing rules changed and now you can't use `self`: 

```
<gfx_macros macros>:4:38: 4:42 error: expected identifier, found keyword `self`
<gfx_macros macros>:4 extern crate "gfx" as gfx_ ; pub use self :: gfx_ as gfx ; }

// Repeat ad-nauseum
```