### PR TITLE
Clean-up warnings from alpha changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,22 @@
 # limitations under the License.
 
 [package]
-
 name = "gfx"
 version = "0.1.0"
 description = "A high-performance, bindless graphics API"
-
 homepage = "https://github.com/bjz/noise-rs"
 repository = "https://github.com/bjz/noise-rs"
 keywords = ["graphics", "gamedev"]
-
 license = "Apache-2.0"
 authors = ["The Gfx-rs Developers"]
-
 
 [lib]
 name = "gfx"
 path = "src/gfx/lib.rs"
+
+[dependencies]
+log = "*"
+time = "*"
 
 [dependencies.gfx_macros]
 path = "src/gfx_macros"
@@ -40,37 +40,11 @@ path = "src/device/"
 [dependencies.render]
 path = "src/render/"
 
-[dependencies]
-log = "*"
-time = "*"
-
-[[example]]
-name = "triangle"
-path = "examples/triangle/main.rs"
-
 [dev_dependencies.glfw]
 git = "https://github.com/bjz/glfw-rs.git"
 
-[[example]]
-name = "cube"
-path = "examples/cube/main.rs"
-
-# [dev_dependencies.glfw]
-# git = "https://github.com/bjz/glfw-rs.git"
-
 [dev_dependencies.cgmath]
 git = "https://github.com/bjz/cgmath-rs"
-
-
-[[example]]
-name = "terrain"
-path = "examples/terrain/main.rs"
-
-# [dev_dependencies.glfw]
-# git = "https://github.com/bjz/glfw-rs.git"
-
-# [dev_dependencies.cgmath]
-# git = "https://github.com/bjz/cgmath-rs"
 
 [dev_dependencies.genmesh]
 git = "https://github.com/csherratt/genmesh.git"
@@ -78,6 +52,19 @@ git = "https://github.com/csherratt/genmesh.git"
 [dev_dependencies.noise]
 git = "https://github.com/bjz/noise-rs.git"
 
+[dev_dependencies.glutin]
+git = "https://github.com/tomaka/glutin.git"
+
+[dev_dependencies.gfx_gl]
+git = "https://github.com/gfx-rs/gfx_gl.git"
+
+[[example]]
+name = "cube"
+path = "examples/cube/main.rs"
+
+[[example]]
+name = "terrain"
+path = "examples/terrain/main.rs"
 
 [[example]]
 name = "deferred"
@@ -87,19 +74,10 @@ path = "examples/deferred/main.rs"
 name = "glutin"
 path = "examples/glutin/main.rs"
 
-[dev_dependencies.glutin]
-git = "https://github.com/tomaka/glutin.git"
-
 [[example]]
 name = "performance"
 path = "examples/performance/main.rs"
 
-# [dev_dependencies.glfw]
-# git = "https://github.com/bjz/glfw-rs.git"
-
-[dev_dependencies.gfx_gl]
-git = "https://github.com/gfx-rs/gfx_gl.git"
-
-# [dev_dependencies.cgmath]
-# git = "https://github.com/bjz/cgmath-rs"
-
+[[example]]
+name = "triangle"
+path = "examples/triangle/main.rs"

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -70,7 +70,7 @@ impl DataBuffer {
     /// Return a reference to a stored data object.
     pub fn get_ref(&self, data: DataPointer) -> &[u8] {
         let DataPointer(offset, size) = data;
-        self.buf.slice(offset as uint, offset as uint + size as uint)
+        self.buf.slice(offset as usize, offset as usize + size as usize)
     }
 }
 
@@ -97,7 +97,7 @@ pub trait CommandBuffer {
     fn bind_uniform(&mut self, shade::Location, shade::UniformValue);
     fn bind_texture(&mut self, ::TextureSlot, tex::TextureKind, back::Texture,
                     Option<::SamplerHandle>);
-    fn set_draw_color_buffers(&mut self, uint);
+    fn set_draw_color_buffers(&mut self, usize);
     fn set_primitive(&mut self, ::state::Primitive);
     fn set_viewport(&mut self, target::Rect);
     fn set_multi_sample(&mut self, Option<::state::MultiSample>);
@@ -106,7 +106,7 @@ pub trait CommandBuffer {
                          Option<::state::Stencil>, ::state::CullMode);
     fn set_blend(&mut self, Option<::state::Blend>);
     fn set_color_mask(&mut self, ::state::ColorMask);
-    fn update_buffer(&mut self, back::Buffer, DataPointer, uint);
+    fn update_buffer(&mut self, back::Buffer, DataPointer, usize);
     fn update_texture(&mut self, tex::TextureKind, back::Texture,
                       tex::ImageInfo, DataPointer);
     fn call_clear(&mut self, target::ClearData, target::Mask);

--- a/src/device/shade.rs
+++ b/src/device/shade.rs
@@ -100,7 +100,7 @@ pub enum Stage {
 // Describing program data
 
 /// Location of a parameter in the program.
-pub type Location = uint;
+pub type Location = usize;
 
 // unable to derive anything for fixed arrays
 /// A value that can be uploaded to the device as a uniform.
@@ -174,32 +174,32 @@ impl fmt::Show for UniformValue {
             UniformValue::I32(x)            => write!(f, "ValueI32({:?})", x),
             UniformValue::F32(x)            => write!(f, "ValueF32({:?})", x),
 
-            UniformValue::I32Vector2(ref v) => write!(f, "ValueI32Vector2({:?})", v.as_slice()),
-            UniformValue::I32Vector3(ref v) => write!(f, "ValueI32Vector3({:?})", v.as_slice()),
-            UniformValue::I32Vector4(ref v) => write!(f, "ValueI32Vector4({:?})", v.as_slice()),
+            UniformValue::I32Vector2(ref v) => write!(f, "ValueI32Vector2({:?})", &v[]),
+            UniformValue::I32Vector3(ref v) => write!(f, "ValueI32Vector3({:?})", &v[]),
+            UniformValue::I32Vector4(ref v) => write!(f, "ValueI32Vector4({:?})", &v[]),
 
-            UniformValue::F32Vector2(ref v) => write!(f, "ValueF32Vector2({:?})", v.as_slice()),
-            UniformValue::F32Vector3(ref v) => write!(f, "ValueF32Vector3({:?})", v.as_slice()),
-            UniformValue::F32Vector4(ref v) => write!(f, "ValueF32Vector4({:?})", v.as_slice()),
+            UniformValue::F32Vector2(ref v) => write!(f, "ValueF32Vector2({:?})", &v[]),
+            UniformValue::F32Vector3(ref v) => write!(f, "ValueF32Vector3({:?})", &v[]),
+            UniformValue::F32Vector4(ref v) => write!(f, "ValueF32Vector4({:?})", &v[]),
 
             UniformValue::F32Matrix2(ref m) => {
                 try!(write!(f, "ValueF32Matrix2("));
                 for v in m.iter() {
-                    try!(write!(f, "{:?}", v.as_slice()));
+                    try!(write!(f, "{:?}", &v[]));
                 }
                 write!(f, ")")
             },
             UniformValue::F32Matrix3(ref m) => {
                 try!(write!(f, "ValueF32Matrix3("));
                 for v in m.iter() {
-                    try!(write!(f, "{:?}", v.as_slice()));
+                    try!(write!(f, "{:?}", &v[]));
                 }
                 write!(f, ")")
             },
             UniformValue::F32Matrix4(ref m) => {
                 try!(write!(f, "ValueF32Matrix4("));
                 for v in m.iter() {
-                    try!(write!(f, "{:?}", v.as_slice()));
+                    try!(write!(f, "{:?}", &v[]));
                 }
                 write!(f, ")")
             },
@@ -213,9 +213,9 @@ pub struct Attribute {
     /// Name of this attribute.
     pub name: String,
     /// Vertex attribute binding.
-    pub location: uint,
+    pub location: usize,
     /// Number of elements this attribute represents.
-    pub count: uint,
+    pub count: usize,
     /// Type that this attribute is composed of.
     pub base_type: BaseType,
     /// "Scalarness" of this attribute.
@@ -230,7 +230,7 @@ pub struct UniformVar {
     /// Location of this uniform in the program.
     pub location: Location,
     /// Number of elements this uniform represents.
-    pub count: uint,
+    pub count: usize,
     /// Type that this uniform is composed of
     pub base_type: BaseType,
     /// "Scalarness" of this uniform.
@@ -243,7 +243,7 @@ pub struct BlockVar {
     /// Name of this uniform block.
     pub name: String,
     /// Size (in bytes) of this uniform block's data.
-    pub size: uint,
+    pub size: usize,
     /// What program stage this uniform block can be used in, as a bitflag.
     pub usage: u8,
 }

--- a/src/device/state.rs
+++ b/src/device/state.rs
@@ -293,7 +293,7 @@ impl Clone for Blend {
 impl fmt::Show for Blend {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Blend {{ color: {:?}, alpha: {:?}, value: {:?} }}",
-               self.color, self.alpha, self.value.as_slice())
+               self.color, self.alpha, &self.value[])
     }
 }
 

--- a/src/device/target.rs
+++ b/src/device/target.rs
@@ -84,7 +84,7 @@ impl fmt::Show for ClearData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f,
             "ClearData {{ color: {:?}, depth: {:?}, stencil: {:?} }}",
-            self.color.as_slice(), self.depth, self.stencil)
+            &self.color[], self.depth, self.stencil)
     }
 }
 

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -44,7 +44,7 @@ pub enum TextureError {
     /// The given TextureInfo contains invalid values.
     InvalidTextureInfo(TextureInfo),
     /// The given data has a different size than the target texture slice.
-    IncorrectTextureSize(uint),
+    IncorrectTextureSize(usize),
 }
 
 impl fmt::Show for TextureError {

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -15,6 +15,8 @@
 //! An efficient, low-level, bindless graphics API for Rust. See [the
 //! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
 
+#![allow(unstable)]
+
 #[macro_use]
 extern crate log;
 extern crate libc;

--- a/src/gfx_macros/lib.rs
+++ b/src/gfx_macros/lib.rs
@@ -55,10 +55,10 @@ fn find_name(cx: &mut ext::base::ExtCtxt, span: codemap::Span,
                     ("name", &ast::LitStr(ref new_name, _)) => {
                         attr::mark_used(attribute);
                         name.map_or(Some(new_name.clone()), |name| {
-                            cx.span_warn(span, format!(
+                            cx.span_warn(span, &format!(
                                 "Extra field name detected: {:?} - \
                                 ignoring in favour of: {:?}", new_name, name
-                            ).as_slice());
+                            )[]);
                             None
                         })
                     }
@@ -128,13 +128,13 @@ struct ExternCrateHackFolder {
 impl Folder for ExternCrateHackFolder {
     fn fold_path(&mut self, p: ast::Path) -> ast::Path {
         let p = syntax::fold::noop_fold_path(p, self);
-        let needs_fix = p.segments.as_slice().get(0)
+        let needs_fix = (&p.segments[]).get(0)
                          .map(|s| s.identifier.as_str() == EXTERN_CRATE_HACK)
                          .unwrap_or(false);
-        let needs_fix_self = p.segments.as_slice().get(0)
+        let needs_fix_self = (&p.segments[]).get(0)
                               .map(|s| s.identifier.as_str() == "self")
                               .unwrap_or(false) &&
-                             p.segments.as_slice().get(1)
+                             (&p.segments[]).get(1)
                               .map(|s| s.identifier.as_str() == EXTERN_CRATE_HACK)
                               .unwrap_or(false);
 

--- a/src/gl_device/draw.rs
+++ b/src/gl_device/draw.rs
@@ -87,7 +87,7 @@ impl ::draw::CommandBuffer for GlCommandBuffer {
         self.buf.push(Command::BindTexture(slot, kind, tex, sampler));
     }
 
-    fn set_draw_color_buffers(&mut self, num: uint) {
+    fn set_draw_color_buffers(&mut self, num: usize) {
         self.buf.push(Command::SetDrawColorBuffers(num));
     }
 
@@ -121,7 +121,7 @@ impl ::draw::CommandBuffer for GlCommandBuffer {
     }
 
     fn update_buffer(&mut self, buf: super::Buffer, data: ::draw::DataPointer,
-                        offset_bytes: uint) {
+                        offset_bytes: usize) {
         self.buf.push(Command::UpdateBuffer(buf, data, offset_bytes));
     }
 

--- a/src/gl_device/info.rs
+++ b/src/gl_device/info.rs
@@ -132,10 +132,10 @@ fn get_string(gl: &gl::Gl, name: gl::types::GLenum) -> &'static str {
     }
 }
 
-fn get_uint(gl: &gl::Gl, name: gl::types::GLenum) -> uint {
+fn get_usize(gl: &gl::Gl, name: gl::types::GLenum) -> usize {
     let mut value = 0 as gl::types::GLint;
     unsafe { gl.GetIntegerv(name, &mut value) };
-    value as uint
+    value as usize
 }
 
 unsafe fn c_str_as_static_str(c_str: *const i8) -> &'static str {
@@ -179,8 +179,8 @@ impl Info {
         let version = Version::parse(get_string(gl, gl::VERSION)).unwrap();
         let shading_language = Version::parse(get_string(gl, gl::SHADING_LANGUAGE_VERSION)).unwrap();
         let extensions = if version >= Version::new(3, 2, None, "") {
-            let num_exts = get_uint(gl, gl::NUM_EXTENSIONS) as gl::types::GLuint;
-            range(0, num_exts)
+            let num_exts = get_usize(gl, gl::NUM_EXTENSIONS) as gl::types::GLuint;
+            (0..num_exts)
                 .map(|i| unsafe { c_str_as_static_str(gl.GetStringi(gl::EXTENSIONS, i) as *const i8) })
                 .collect()
         } else {
@@ -223,9 +223,9 @@ pub fn get(gl: &gl::Gl) -> (Info, Capabilities) {
     let caps = Capabilities {
         shader_model:                   to_shader_model(&info.shading_language),
 
-        max_draw_buffers:               get_uint(gl, gl::MAX_DRAW_BUFFERS),
-        max_texture_size:               get_uint(gl, gl::MAX_TEXTURE_SIZE),
-        max_vertex_attributes:          get_uint(gl, gl::MAX_VERTEX_ATTRIBS),
+        max_draw_buffers:               get_usize(gl, gl::MAX_DRAW_BUFFERS),
+        max_texture_size:               get_usize(gl, gl::MAX_TEXTURE_SIZE),
+        max_vertex_attributes:          get_usize(gl, gl::MAX_VERTEX_ATTRIBS),
 
         array_buffer_supported:         info.is_version_or_extension_supported(3, 0, "GL_ARB_vertex_array_object"),
         fragment_output_supported:      info.is_version_or_extension_supported(3, 0, "GL_ARB_gpu_shader4"),

--- a/src/gl_device/lib.rs
+++ b/src/gl_device/lib.rs
@@ -16,6 +16,7 @@
 //! least VAOs, but using newer extensions when available.
 
 #![allow(missing_docs)]
+#![allow(unstable)]
 #![experimental]
 #![deny(missing_copy_implementations)]
 
@@ -42,6 +43,7 @@ mod state;
 mod tex;
 mod info;
 
+#[allow(raw_pointer_derive)]
 #[derive(Copy)]
 pub struct RawMapping {
     pub pointer: *mut libc::c_void,
@@ -210,7 +212,7 @@ impl GlDevice {
     }
 
     fn update_sub_buffer(&mut self, buffer: Buffer, address: *const u8,
-                         size: uint, offset: uint) {
+                         size: usize, offset: usize) {
         unsafe { self.gl.BindBuffer(gl::ARRAY_BUFFER, buffer) };
         unsafe {
             self.gl.BufferSubData(gl::ARRAY_BUFFER,
@@ -575,7 +577,7 @@ impl Device<GlCommandBuffer> for GlDevice {
         }
     }
 
-    fn create_buffer_raw(&mut self, size: uint, usage: BufferUsage) -> ::BufferHandle<()> {
+    fn create_buffer_raw(&mut self, size: usize, usage: BufferUsage) -> ::BufferHandle<()> {
         let name = self.create_buffer_internal();
         let info = ::BufferInfo {
             usage: usage,
@@ -716,7 +718,7 @@ impl Device<GlCommandBuffer> for GlDevice {
     }
 
     fn update_buffer_raw(&mut self, buffer: ::BufferHandle<()>, data: &[u8],
-                         offset_bytes: uint) {
+                         offset_bytes: usize) {
         debug_assert!(offset_bytes + data.len() <= buffer.get_info().size);
         self.update_sub_buffer(buffer.get_name(), data.as_ptr(), data.len(),
                                offset_bytes)

--- a/src/gl_device/state.rs
+++ b/src/gl_device/state.rs
@@ -66,7 +66,7 @@ pub fn bind_multi_sample(gl: &gl::Gl, ms: Option<s::MultiSample>) {
     }
 }
 
-pub fn bind_draw_color_buffers(gl: &gl::Gl, num: uint) {
+pub fn bind_draw_color_buffers(gl: &gl::Gl, num: usize) {
     unsafe { gl.DrawBuffers(
         num as i32,
         [gl::COLOR_ATTACHMENT0,  gl::COLOR_ATTACHMENT1,  gl::COLOR_ATTACHMENT2,

--- a/src/gl_device/tex.rs
+++ b/src/gl_device/tex.rs
@@ -159,7 +159,7 @@ fn components_to_glpixel(c: Components) -> GLenum {
     }
 }
 
-fn components_to_count(c: Components) -> uint {
+fn components_to_count(c: Components) -> usize {
     match c {
         Components::R    => 1,
         Components::RG   => 2,
@@ -199,13 +199,13 @@ fn format_to_gltype(t: Format) -> Result<GLenum, ()> {
     }
 }
 
-fn format_to_size(t: tex::Format) -> uint {
+fn format_to_size(t: tex::Format) -> usize {
     match t {
         Format::Float(c, FloatSize::F16) => 2 * components_to_count(c),
         Format::Float(c, FloatSize::F32) => 4 * components_to_count(c),
         Format::Float(c, FloatSize::F64) => 8 * components_to_count(c),
-        Format::Integer(c, bits, _)  => bits as uint * components_to_count(c) >> 3,
-        Format::Unsigned(c, bits, _) => bits as uint * components_to_count(c) >> 3,
+        Format::Integer(c, bits, _)  => bits as usize * components_to_count(c) >> 3,
+        Format::Unsigned(c, bits, _) => bits as usize * components_to_count(c) >> 3,
         Format::Compressed(_) => panic!("Tried to get size of a compressed texel!"),
         Format::R3G3B2       => 1,
         Format::RGB5A1       => 2,
@@ -537,12 +537,12 @@ pub fn bind_sampler(gl: &gl::Gl, anchor: BindAnchor, info: &tex::SamplerInfo) { 
 }}
 
 pub fn update_texture(gl: &gl::Gl, kind: TextureKind, name: Texture,
-                      img: &tex::ImageInfo, address: *const u8, size: uint)
+                      img: &tex::ImageInfo, address: *const u8, size: usize)
                       -> Result<(), TextureError> {
     if !img.format.is_compressed() {
         // TODO: can we compute the expected size for compressed formats?
-        let expected_size = img.width as uint * img.height as uint *
-                            img.depth as uint * format_to_size(img.format);
+        let expected_size = img.width as usize * img.height as usize *
+                            img.depth as usize * format_to_size(img.format);
         if size != expected_size {
             return Err(TextureError::IncorrectTextureSize(expected_size));
         }

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -54,7 +54,7 @@ pub fn link_mesh(mesh: &mesh::Mesh, pinfo: &ProgramInfo) -> Result<mesh::Link, M
     let mut indices = Vec::new();
     for sat in pinfo.attributes.iter() {
         match mesh.attributes.iter().enumerate()
-                  .find(|&(_, a)| a.name.as_slice() == sat.name.as_slice()) {
+                  .find(|&(_, a)| a.name == sat.name) {
             Some((attrib_id, vat)) => match vat.format.elem_type.is_compatible(sat.base_type) {
                 Ok(_) => indices.push(attrib_id),
                 Err(_) => return Err(MeshError::AttributeType),
@@ -179,7 +179,7 @@ impl<T> Array<T> {
 
     fn get(&self, id: Id<T>) -> &T {
         let Id(i) = id;
-        &self.data[i as uint]
+        &self.data[i as usize]
     }
 }
 

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -187,14 +187,14 @@ impl ToSlice for BufferHandle<u32> {
 #[derive(Clone, Copy, Show)]
 pub enum LinkError {
     /// An attribute index is out of supported bounds
-    MeshAttribute(uint),
+    MeshAttribute(usize),
     /// An input index is out of supported bounds
-    ShaderInput(uint),
+    ShaderInput(usize),
 }
 
-const BITS_PER_ATTRIBUTE: uint = 4;
-const MAX_SHADER_INPUTS: uint = 64 / BITS_PER_ATTRIBUTE;
-const MESH_ATTRIBUTE_MASK: uint = (1u << BITS_PER_ATTRIBUTE) - 1;
+const BITS_PER_ATTRIBUTE: usize = 4;
+const MAX_SHADER_INPUTS: usize = 64 / BITS_PER_ATTRIBUTE;
+const MESH_ATTRIBUTE_MASK: usize = (1 << BITS_PER_ATTRIBUTE) - 1;
 
 /// An iterator over mesh attributes.
 #[derive(Copy)]
@@ -203,10 +203,10 @@ pub struct AttributeIndices {
 }
 
 impl Iterator for AttributeIndices {
-    type Item = uint;
+    type Item = usize;
 
-    fn next(&mut self) -> Option<uint> {
-        let id = (self.value as uint) & MESH_ATTRIBUTE_MASK;
+    fn next(&mut self) -> Option<usize> {
+        let id = (self.value as usize) & MESH_ATTRIBUTE_MASK;
         self.value >>= BITS_PER_ATTRIBUTE;
         Some(id)
     }
@@ -220,7 +220,7 @@ pub struct Link {
 
 impl Link {
     /// Construct a new link from an iterator over attribute indices.
-    pub fn from_iter<I: Iterator<Item=uint>>(iter: I) -> Result<Link, LinkError> {
+    pub fn from_iter<I: Iterator<Item=usize>>(iter: I) -> Result<Link, LinkError> {
         let mut table = 0u64;
         for (input, attrib) in iter.enumerate() {
             if input >= MAX_SHADER_INPUTS {

--- a/src/render/shade.rs
+++ b/src/render/shade.rs
@@ -98,15 +98,15 @@ pub trait ShaderParam<L> {
 
 impl ShaderParam<()> for () {
     fn create_link(_: Option<&()>, info: &shade::ProgramInfo) -> Result<(), ParameterError> {
-        match info.uniforms.as_slice().first() {
+        match info.uniforms[].first() {
             Some(u) => return Err(ParameterError::MissingUniform(u.name.clone())),
             None => (),
         }
-        match info.blocks.as_slice().first() {
+        match info.blocks[].first() {
             Some(b) => return Err(ParameterError::MissingBlock(b.name.clone())),
             None => (),
         }
-        match info.textures.as_slice().first() {
+        match info.textures[].first() {
             Some(t) => return Err(ParameterError::MissingTexture(t.name.clone())),
             None => (),
         }
@@ -139,9 +139,9 @@ pub struct ParamDictionary {
 /// An associated link structure for `ParamDictionary` that redirects program
 /// input to the relevant dictionary cell.
 pub struct ParamDictionaryLink {
-    uniforms: Vec<uint>,
-    blocks: Vec<uint>,
-    textures: Vec<uint>,
+    uniforms: Vec<usize>,
+    blocks: Vec<usize>,
+    textures: Vec<usize>,
 }
 
 impl ShaderParam<ParamDictionaryLink> for ParamDictionary {


### PR DESCRIPTION
This includes mainly slice notation and renaming to usize/isize. The vertex format macro no longer advises against the use of usize/isize specifically, as the new name alone should deter people from using it for numerical purposes.

To suppress the instability warnings, the "unstable" lint is allowed in all crates.

Oh, and I also restructured `Cargo.toml` to get an overview of the dependencies. I could send a separate pull request for this if that is desired.