### PR TITLE
Use bitflags from crates.io

### DIFF
--- a/src/device/Cargo.toml
+++ b/src/device/Cargo.toml
@@ -28,3 +28,4 @@ git = "https://github.com/gfx-rs/gfx_gl.git"
 
 [dependencies]
 log = "*"
+bitflags = "*"

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -22,7 +22,7 @@
 #[macro_use]
 extern crate log;
 #[macro_use]
-extern crate rustc_bitflags;
+extern crate bitflags;
 extern crate libc;
 
 // TODO: Remove these exports once `gl_device` becomes a separate crate.


### PR DESCRIPTION
Fix to use bitflags crate as described in this commit: https://github.com/rust-lang/rust/commit/34fa70fba5425cbbb96bce783e9fd5c23dd9b471. As a bonus, this let older rust versions to compile gfx-rs.