### PR TITLE
BGRA8 texture support

### DIFF
--- a/src/device/gl_device/tex.rs
+++ b/src/device/gl_device/tex.rs
@@ -146,6 +146,7 @@ fn format_to_gl(t: Format) -> Result<GLenum, ()> {
         Format::RGB10A2UI    => gl::RGB10_A2UI,
         Format::R11FG11FB10F => gl::R11F_G11F_B10F,
         Format::RGB9E5       => gl::RGB9_E5,
+        Format::BGRA8        => gl::RGBA8,
         Format::DEPTH24STENCIL8 => gl::DEPTH24_STENCIL8,
     })
 }
@@ -181,6 +182,7 @@ fn format_to_glpixel(t: Format) -> GLenum {
         Format::RGB10A2UI    => gl::RGBA,
         Format::R11FG11FB10F => gl::RGB,
         Format::RGB9E5       => gl::RGB,
+        Format::BGRA8        => gl::BGRA,
         Format::DEPTH24STENCIL8 => gl::DEPTH_STENCIL,
     }
 }
@@ -194,7 +196,8 @@ fn format_to_gltype(t: Format) -> Result<GLenum, ()> {
         Format::Unsigned(_, 16, _) => Ok(gl::UNSIGNED_SHORT),
         Format::Integer(_, 32, _)  => Ok(gl::INT),
         Format::Unsigned(_, 32, _) => Ok(gl::UNSIGNED_INT),
-        Format::DEPTH24STENCIL8   => Ok(gl::UNSIGNED_INT_24_8),
+        Format::BGRA8              => Ok(gl::UNSIGNED_BYTE),
+        Format::DEPTH24STENCIL8    => Ok(gl::UNSIGNED_INT_24_8),
         _ => Err(()),
     }
 }
@@ -213,6 +216,7 @@ fn format_to_size(t: tex::Format) -> usize {
         Format::RGB10A2UI    => 4,
         Format::R11FG11FB10F => 4,
         Format::RGB9E5       => 4,
+        Format::BGRA8        => 4,
         Format::DEPTH24STENCIL8 => 4,
     }
 }

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -107,6 +107,18 @@ pub enum Components {
     RGBA,
 }
 
+/// Codec used to compress image data.
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+#[allow(non_camel_case_types)]
+pub enum Compression {
+    /// Use the EXT2 algorithm on 3 components.
+    ETC2_RGB,
+    /// Use the EXT2 algorithm on 4 components (RGBA) in the sRGB color space.
+    ETC2_SRGB,
+    /// Use the EXT2 EAC algorithm on 4 components.
+    ETC2_EAC_RGBA8,
+}
+
 /// Describes the layout of each texel within a surface/texture.
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
 pub enum Format {
@@ -131,33 +143,28 @@ pub enum Format {
     /// This s an RGB format of type floating-point. The 3 color values have
     /// 9 bits of precision, and they share a single exponent.
     RGB9E5,
+    /// Swizzled RGBA color format, used for interaction with Windows DIBs
+    BGRA8,
     /// 24 bits for depth, 8 for stencil
     DEPTH24STENCIL8,
     // TODO: sRGB
-}
-
-/// Codec used to compress image data.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
-#[allow(non_camel_case_types)]
-pub enum Compression {
-    /// Use the EXT2 algorithm on 3 components.
-    ETC2_RGB,
-    /// Use the EXT2 algorithm on 4 components (RGBA) in the sRGB color space.
-    ETC2_SRGB,
-    /// Use the EXT2 EAC algorithm on 4 components.
-    ETC2_EAC_RGBA8,
 }
 
 impl Format {
     /// Extract the components format
     pub fn get_components(&self) -> Option<Components> {
         Some(match *self {
-            Format::Float(c, _) => c,
-            Format::Integer(c, _, _) => c,
+            Format::Float(c, _)       => c,
+            Format::Integer(c, _, _)  => c,
             Format::Unsigned(c, _, _) => c,
-            Format::Compressed(_) => panic!("Tried to get components of compressed texel!"),
-            Format::R3G3B2 | Format::R11FG11FB10F | Format::RGB9E5    => Components::RGB,
-            Format::RGB5A1 | Format::RGB10A2      | Format::RGB10A2UI => Components::RGBA,
+            Format::Compressed(_)   => panic!("Tried to get components of compressed texel!"),
+            Format::R3G3B2          |
+            Format::R11FG11FB10F    |
+            Format::RGB9E5          => Components::RGB,
+            Format::RGB5A1          |
+            Format::RGB10A2         |
+            Format::RGB10A2UI       |
+            Format::BGRA8           => Components::RGBA,
             Format::DEPTH24STENCIL8 => return None,
         })
     }


### PR DESCRIPTION
Closes #523 

I decided to make BGRA an exception because it has a very limited use case - interoperation with BMP, which is unlikely anything but 8 bit unsigned normalized data.