### PR TITLE
Batch implementation for the components

### DIFF
--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(core, os, env, plugin, std_misc)]
+#![feature(core, env, plugin, std_misc)]
 #![plugin(gfx_macros)]
 
 extern crate cgmath;
@@ -367,9 +367,9 @@ fn main() {
         return;
     }
 
-    let mode = args.nth(1).unwrap().into_string().unwrap();
+    let mode = args.nth(1).unwrap();
     let count: i16 = if args_count == 3 {
-        FromStr::from_str(&args.next().unwrap().into_string().unwrap()).ok()
+        FromStr::from_str(&args.next().unwrap()).ok()
     } else {
         None
     }.unwrap_or(10000);

--- a/examples/triangle/main.rs
+++ b/examples/triangle/main.rs
@@ -18,7 +18,7 @@
 extern crate gfx;
 extern crate glfw;
 
-use gfx::{DeviceExt, ToSlice};
+use gfx::{Device, DeviceExt, ToSlice};
 use glfw::Context;
 
 #[vertex_format]
@@ -82,15 +82,14 @@ fn main() {
     let program = device.link_program(VERTEX_SRC, FRAGMENT_SRC)
                         .ok().expect("Failed to link program");
 
-    let mut graphics = gfx::Graphics::new(device);
-    let batch: gfx::batch::RefBatch<()> = graphics.make_batch(
-        &program, &mesh, slice, &gfx::DrawState::new()).ok().expect("Failed to make batch");
+    let mut renderer = device.create_renderer();
 
     let clear_data = gfx::ClearData {
         color: [0.3, 0.3, 0.3, 1.0],
         depth: 1.0,
         stencil: 0,
     };
+    let state = gfx::DrawState::new();
 
     while !window.should_close() {
         glfw.poll_events();
@@ -102,9 +101,10 @@ fn main() {
             }
         }
 
-        graphics.clear(clear_data, gfx::COLOR, &frame);
-        graphics.draw(&batch, &(), &frame).unwrap();
-        graphics.end_frame();
+        renderer.reset();
+        renderer.clear(clear_data, gfx::COLOR, &frame);
+        renderer.draw(&(&mesh, slice, &program, &(), &state), &frame).unwrap();
+        device.submit(renderer.as_buffer());
 
         window.swap_buffers();
     }

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -89,7 +89,7 @@ impl<D: device::Device> Graphics<D> {
     /// Draw a ref batch.
     pub fn draw<'a, T: shade::ShaderParam>(&'a mut self,
                 batch: &'a batch::RefBatch<T>, data: &'a T, frame: &Frame)
-                -> Result<(), DrawError> {
+                -> Result<(), DrawError<batch::OutOfBounds>> {
         self.renderer.draw(&(batch, data, &self.context), frame)
     }
 


### PR DESCRIPTION
Fixes #556 

Note: this PR does not change the API.

Please have a good look at it before submission: `Batch` interface is changed. I feel that it is more sound now, since the program and its parameters are handled by the `fill_params` method, while `get_data` is mostly taking care of the mesh.

The batch errors appeared to be useful for the `RefBatch` as well as the new component-based implementation, because `RefBatch` can technically be used with the wrong context.

Also, the `AttributeIndex` type seems to improve read-ability of the code.