### PR TITLE
Parameterise Renderer over Device and rename CommandBufferHelper

### DIFF
--- a/src/device/gl_device/lib.rs
+++ b/src/device/gl_device/lib.rs
@@ -28,9 +28,9 @@ use state::{CullMode, RasterMethod, WindingOrder};
 use target::{Access, Target};
 
 use BufferUsage;
-use Command;
 use Device;
 use {MapAccess, ReadableMapping, WritableMapping, RWMapping, BufferHandle, PrimitiveType};
+use self::draw::Command;
 
 pub use self::draw::GlCommandBuffer;
 pub use self::info::{Info, PlatformName, Version};
@@ -170,7 +170,7 @@ impl GlDevice {
     }
 
     /// Fails during a debug build if the implementation's error flag was set.
-    fn check(&mut self, cmd: &::Command) {
+    fn check(&mut self, cmd: &Command) {
         if cfg!(not(ndebug)) {
             let err = GlError::from_error_code(unsafe { self.gl.GetError() });
             if err != GlError::NoError {
@@ -221,7 +221,7 @@ impl GlDevice {
         }
     }
 
-    fn process(&mut self, cmd: &::Command, data_buf: &::draw::DataBuffer) {
+    fn process(&mut self, cmd: &Command, data_buf: &::draw::DataBuffer) {
         match *cmd {
             Command::Clear(ref data, mask) => {
                 let mut flags = 0;

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -315,45 +315,6 @@ pub struct BufferInfo {
     pub size: usize,
 }
 
-/// Serialized device command.
-/// While this is supposed to be an internal detail of a device,
-/// this particular representation may be used by different backends,
-/// such as OpenGL (prior to GLNG) and DirectX (prior to DX12)
-#[allow(missing_docs)]
-#[derive(Copy, Debug)]
-pub enum Command {
-    BindProgram(back::Program),
-    BindArrayBuffer(back::ArrayBuffer),
-    BindAttribute(AttributeSlot, back::Buffer, attrib::Format),
-    BindIndex(back::Buffer),
-    BindFrameBuffer(target::Access, back::FrameBuffer),
-    /// Unbind any surface from the specified target slot
-    UnbindTarget(target::Access, target::Target),
-    /// Bind a surface to the specified target slot
-    BindTargetSurface(target::Access, target::Target, back::Surface),
-    /// Bind a level of the texture to the specified target slot
-    BindTargetTexture(target::Access, target::Target, back::Texture,
-                      target::Level, Option<target::Layer>),
-    BindUniformBlock(back::Program, UniformBufferSlot, UniformBlockIndex, back::Buffer),
-    BindUniform(shade::Location, shade::UniformValue),
-    BindTexture(TextureSlot, tex::TextureKind, back::Texture, Option<SamplerHandle>),
-    SetDrawColorBuffers(usize),
-    SetPrimitiveState(state::Primitive),
-    SetViewport(target::Rect),
-    SetMultiSampleState(Option<state::MultiSample>),
-    SetScissor(Option<target::Rect>),
-    SetDepthStencilState(Option<state::Depth>, Option<state::Stencil>, state::CullMode),
-    SetBlendState(Option<state::Blend>),
-    SetColorMask(state::ColorMask),
-    UpdateBuffer(back::Buffer, draw::DataPointer, usize),
-    UpdateTexture(tex::TextureKind, back::Texture, tex::ImageInfo, draw::DataPointer),
-    // drawing
-    Clear(target::ClearData, target::Mask),
-    Draw(PrimitiveType, VertexCount, VertexCount, Option<(InstanceCount, VertexCount)>),
-    DrawIndexed(PrimitiveType, IndexType, VertexCount, VertexCount, VertexCount, Option<(InstanceCount, VertexCount)>),
-    Blit(target::Rect, target::Rect, target::Mirror, target::Mask),
-}
-
 /// An interface for performing draw calls using a specific graphics API
 #[allow(missing_docs)]
 pub trait Device {

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -55,7 +55,7 @@ pub struct Graphics<D: device::Device> {
     /// Graphics device.
     pub device: D,
     /// Renderer front-end.
-    pub renderer: Renderer<<D as device::Device>::CommandBuffer>,
+    pub renderer: Renderer<D>,
     /// Hidden batch context.
     context: batch::Context,
 }

--- a/src/render/device_ext.rs
+++ b/src/render/device_ext.rs
@@ -59,7 +59,7 @@ impl<'a> ShaderSource<'a> {
 /// Backend extension trait for convenience methods
 pub trait DeviceExt: device::Device {
     /// Create a new renderer
-    fn create_renderer(&mut self) -> ::Renderer<<Self as device::Device>::CommandBuffer>;
+    fn create_renderer(&mut self) -> ::Renderer<Self>;
     /// Create a new mesh from the given vertex data.
     /// Convenience function around `create_buffer` and `Mesh::from_format`.
     fn create_mesh<T: VertexFormat + Copy>(&mut self, data: &[T]) -> Mesh;
@@ -73,7 +73,7 @@ pub trait DeviceExt: device::Device {
 }
 
 impl<D: device::Device> DeviceExt for D {
-    fn create_renderer(&mut self) -> ::Renderer<D::CommandBuffer> {
+    fn create_renderer(&mut self) -> ::Renderer<D> {
         ::Renderer {
             command_buffer: device::draw::CommandBuffer::new(),
             data_buffer: device::draw::DataBuffer::new(),

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -105,14 +105,14 @@ impl ParamStorage{
     }
 }
 
-/// Helper routines for the command buffer
+/// Extension methods for the command buffer.
 /// Useful when Renderer is borrowed, and we need to issue commands.
-trait CommandBufferHelper {
+trait CommandBufferExt {
     /// Bind a plane to some target
     fn bind_target(&mut self, Access, Target, Option<&target::Plane>);
 }
 
-impl<C: CommandBuffer> CommandBufferHelper for C {
+impl<C: CommandBuffer> CommandBufferExt for C {
     fn bind_target(&mut self, access: Access, to: Target,
                    plane: Option<&target::Plane>) {
         match plane {

--- a/src/render/lib.rs
+++ b/src/render/lib.rs
@@ -22,6 +22,7 @@ extern crate "gfx_device_gl" as device;
 
 use std::mem;
 
+use device::Device;
 use device::attrib;
 use device::attrib::IntSize;
 use device::draw::CommandBuffer;
@@ -141,8 +142,8 @@ pub enum DrawError<E> {
 }
 
 /// Renderer front-end
-pub struct Renderer<C: CommandBuffer> {
-    command_buffer: C,
+pub struct Renderer<D: Device> {
+    command_buffer: D::CommandBuffer,
     data_buffer: device::draw::DataBuffer,
     common_array_buffer: Result<device::ArrayBufferHandle, ()>,
     draw_frame_buffer: device::FrameBufferHandle,
@@ -152,7 +153,7 @@ pub struct Renderer<C: CommandBuffer> {
     parameters: ParamStorage,
 }
 
-impl<C: CommandBuffer> Renderer<C> {
+impl<D: Device> Renderer<D> {
     /// Reset all commands for the command buffer re-usal.
     pub fn reset(&mut self) {
         self.command_buffer.clear();
@@ -161,12 +162,12 @@ impl<C: CommandBuffer> Renderer<C> {
     }
 
     /// Get command and data buffers to be submitted to the device.
-    pub fn as_buffer(&self) -> (&C, &device::draw::DataBuffer) {
+    pub fn as_buffer(&self) -> (&D::CommandBuffer, &device::draw::DataBuffer) {
         (&self.command_buffer, &self.data_buffer)
     }
 
     /// Clone the renderer shared data but ignore the commands.
-    pub fn clone_empty(&self) -> Renderer<C> {
+    pub fn clone_empty(&self) -> Renderer<D> {
         Renderer {
             command_buffer: CommandBuffer::new(),
             data_buffer: device::draw::DataBuffer::new(),


### PR DESCRIPTION
`Renderer` contains handles that will be associated on `Device` in the future when we implement #416.