### PR TITLE
Add resources parameter to types in render::target

### DIFF
--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -308,8 +308,9 @@ fn calculate_color(height: f32) -> [f32; 3] {
 }
 
 fn create_g_buffer(width: u16, height: u16, device: &mut gfx::GlDevice)
-        -> (gfx::Frame, TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>,
-            TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>) {
+        -> (gfx::Frame<gfx::GlResources>, TextureHandle<gfx::GlResources>,
+            TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>,
+            TextureHandle<gfx::GlResources>) {
     let mut frame = gfx::Frame::new(width, height);
 
     let texture_info_float = gfx::tex::TextureInfo {
@@ -346,7 +347,7 @@ fn create_g_buffer(width: u16, height: u16, device: &mut gfx::GlDevice)
 }
 
 fn create_res_buffer(width: u16, height: u16, device: &mut gfx::GlDevice, texture_depth: TextureHandle<gfx::GlResources>)
-        -> (gfx::Frame, TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>) {
+        -> (gfx::Frame<gfx::GlResources>, TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>) {
     let mut frame = gfx::Frame::new(width, height);
 
     let texture_info_float = gfx::tex::TextureInfo {

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -42,7 +42,7 @@ use std::num::Float;
 use cgmath::FixedArray;
 use cgmath::{Matrix, Matrix4, Point3, Vector3, EuclideanVector};
 use cgmath::{Transform, AffineMatrix3};
-use gfx::{Device, DeviceExt, TextureHandle, Plane, ToSlice, RawBufferHandle};
+use gfx::{Device, DeviceExt, Plane, ToSlice, RawBufferHandle};
 use gfx::batch::RefBatch;
 use glfw::Context;
 use genmesh::{Vertices, Triangulate};
@@ -307,10 +307,11 @@ fn calculate_color(height: f32) -> [f32; 3] {
     }
 }
 
+type Frame = gfx::Frame<gfx::GlResources>;
+type Texture = gfx::TextureHandle<gfx::GlResources>;
+
 fn create_g_buffer(width: u16, height: u16, device: &mut gfx::GlDevice)
-        -> (gfx::Frame<gfx::GlResources>, TextureHandle<gfx::GlResources>,
-            TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>,
-            TextureHandle<gfx::GlResources>) {
+        -> (Frame, Texture, Texture, Texture, Texture) {
     let mut frame = gfx::Frame::new(width, height);
 
     let texture_info_float = gfx::tex::TextureInfo {
@@ -346,8 +347,8 @@ fn create_g_buffer(width: u16, height: u16, device: &mut gfx::GlDevice)
     (frame, texture_pos, texture_normal, texture_diffuse, texture_depth)
 }
 
-fn create_res_buffer(width: u16, height: u16, device: &mut gfx::GlDevice, texture_depth: TextureHandle<gfx::GlResources>)
-        -> (gfx::Frame<gfx::GlResources>, TextureHandle<gfx::GlResources>, TextureHandle<gfx::GlResources>) {
+fn create_res_buffer(width: u16, height: u16, device: &mut gfx::GlDevice, texture_depth: Texture)
+        -> (Frame, Texture, Texture) {
     let mut frame = gfx::Frame::new(width, height);
 
     let texture_info_float = gfx::tex::TextureInfo {
@@ -571,7 +572,7 @@ fn main() {
         tex: (texture_pos, Some(sampler)),
     };
 
-    let mut debug_buf: Option<TextureHandle<gfx::GlResources>> = None;
+    let mut debug_buf: Option<Texture> = None;
 
     let mut light_pos_vec: Vec<[f32; 4]> = (0 ..NUM_LIGHTS).map(|_| {
         [0.0, 0.0, 0.0, 0.0]

--- a/src/device/gl_device/lib.rs
+++ b/src/device/gl_device/lib.rs
@@ -56,7 +56,7 @@ pub type Surface        = gl::types::GLuint;
 pub type Sampler        = gl::types::GLuint;
 pub type Texture        = gl::types::GLuint;
 
-#[derive(Copy)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum GlResources {}
 
 impl Resources for GlResources {

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -165,32 +165,10 @@ impl<T, I> Handle<T, I> {
 }
 
 /// Type-safe buffer handle
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct BufferHandle<R: Resources, T> {
     raw: RawBufferHandle<R>,
-    phantom_t: PhantomData<T>
-}
-
-impl<R: Resources, T> Copy for BufferHandle<R, T> {}
-
-impl<R: Resources, T> Clone for BufferHandle<R, T> {
-    fn clone(&self) -> BufferHandle<R, T> {
-        BufferHandle {
-            raw: self.raw,
-            phantom_t: PhantomData
-        }
-    }
-}
-
-impl<R: Resources, T> PartialEq for BufferHandle<R, T> {
-    fn eq(&self, other: &BufferHandle<R, T>) -> bool {
-        self.raw == other.raw
-    }
-}
-
-impl<R: Resources, T> fmt::Debug for BufferHandle<R, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "BufferHandle {{ raw: {:?} }}", self.raw)
-    }
+    phantom_t: PhantomData<T>,
 }
 
 impl<R: Resources, T> BufferHandle<R, T> {
@@ -198,7 +176,7 @@ impl<R: Resources, T> BufferHandle<R, T> {
     pub fn from_raw(handle: RawBufferHandle<R>) -> BufferHandle<R, T> {
         BufferHandle {
             raw: handle,
-            phantom_t: PhantomData
+            phantom_t: PhantomData,
         }
     }
 
@@ -347,8 +325,8 @@ pub struct BufferInfo {
     pub size: usize,
 }
 
-/// Resources pertaining to a specific API
-pub trait Resources: PhantomFn<Self> {
+/// Resources pertaining to a specific API.
+pub trait Resources: PhantomFn<Self> + Copy + Clone + PartialEq + fmt::Debug {
     type Buffer:        Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
     type ArrayBuffer:   Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
     type Shader:        Copy + Clone + fmt::Debug + PartialEq + Send + Sync;

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -82,13 +82,13 @@ impl<D: device::Device> Graphics<D> {
     }
 
     /// Clear the `Frame` as the `ClearData` specifies.
-    pub fn clear(&mut self, data: ClearData, mask: Mask, frame: &Frame) {
+    pub fn clear(&mut self, data: ClearData, mask: Mask, frame: &Frame<GlResources>) {
         self.renderer.clear(data, mask, frame)
     }
 
     /// Draw a ref batch.
     pub fn draw<'a, T: shade::ShaderParam>(&'a mut self,
-                batch: &'a batch::RefBatch<T>, data: &'a T, frame: &Frame)
+                batch: &'a batch::RefBatch<T>, data: &'a T, frame: &Frame<GlResources>)
                 -> Result<(), DrawError<batch::OutOfBounds>> {
         self.renderer.draw(&(batch, data, &self.context), frame)
     }

--- a/src/render/target.rs
+++ b/src/render/target.rs
@@ -15,20 +15,20 @@
 //! Render target specification.
 
 use device;
-use device::back;
+use device::Resources;
 use device::target::{Level, Layer, Mask};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 /// A single buffer that can be bound to a render target.
-pub enum Plane {
+pub enum Plane<R: Resources> {
     /// Render to a `Surface` (corresponds to a renderbuffer in GL).
-    Surface(device::SurfaceHandle<back::GlResources>),
+    Surface(device::SurfaceHandle<R>),
     /// Render to a texture at a specific mipmap level
     /// If `Layer` is set, it is selecting a single 2D slice of a given 3D texture
-    Texture(device::TextureHandle<back::GlResources>, Level, Option<Layer>),
+    Texture(device::TextureHandle<R>, Level, Option<Layer>),
 }
 
-impl Plane {
+impl<R: Resources> Plane<R> {
     /// Get the surface info
     pub fn get_surface_info(&self) -> device::tex::SurfaceInfo {
         match *self {
@@ -40,23 +40,23 @@ impl Plane {
 
 /// A complete `Frame`, which is the result of rendering.
 #[derive(Clone, PartialEq, Debug)]
-pub struct Frame {
+pub struct Frame<R: Resources> {
     /// The width of the viewport.
     pub width: u16,
     /// The height of the viewport.
     pub height: u16,
     /// Each color component has its own buffer.
-    pub colors: Vec<Plane>,
+    pub colors: Vec<Plane<R>>,
     /// The depth buffer for this frame.
-    pub depth: Option<Plane>,
+    pub depth: Option<Plane<R>>,
     /// The stencil buffer for this frame.
-    pub stencil: Option<Plane>,
+    pub stencil: Option<Plane<R>>,
 }
 
-impl Frame {
+impl<R: Resources> Frame<R> {
     /// Create an empty `Frame`, which corresponds to the 'default framebuffer',
     /// which renders directly to the window that was created with the OpenGL context.
-    pub fn new(width: u16, height: u16) -> Frame {
+    pub fn new(width: u16, height: u16) -> Frame<R> {
         Frame {
             width: width,
             height: height,


### PR DESCRIPTION
I have also constrained `Resources` by additional bounds. This allows for the usage of `#[derive(...)]` when a type is parameterised over `Resources`.