### PR TITLE
Parametrise batches over Resources

### DIFF
--- a/examples/cube/main.rs
+++ b/examples/cube/main.rs
@@ -174,8 +174,10 @@ fn main() {
 
     let state = gfx::DrawState::new().depth(gfx::state::Comparison::LessEqual, true);
 
-    let batch: RefBatch<Params> = context.make_batch(&program, &mesh, slice, &state)
-                                         .ok().expect("Failed to make batch.");
+    let batch: RefBatch<Params, gfx::GlResources> = {
+        context.make_batch(&program, &mesh, slice, &state)
+               .ok().expect("Failed to make batch.")
+    };
 
     let view: AffineMatrix3<f32> = Transform::look_at(
         &Point3::new(1.5f32, -5.0, 3.0),

--- a/examples/deferred/main.rs
+++ b/examples/deferred/main.rs
@@ -402,7 +402,7 @@ fn main() {
     };
 
     let terrain_scale = Vector3::new(25.0, 25.0, 25.0);
-    let terrain_batch: RefBatch<TerrainParams> = {
+    let terrain_batch: RefBatch<TerrainParams, gfx::GlResources> = {
         let plane = genmesh::generators::Plane::subdivide(256, 256);
         let vertex_data: Vec<TerrainVertex> = plane.shared_vertex_iter()
             .map(|(x, y)| {
@@ -435,7 +435,7 @@ fn main() {
                .ok().expect("Failed to match back")
     };
 
-    let blit_batch: RefBatch<BlitParams> = {
+    let blit_batch: RefBatch<BlitParams, gfx::GlResources> = {
         let vertex_data = [
             BlitVertex { pos: [-1, -1, 0], tex_coord: [0, 0] },
             BlitVertex { pos: [ 1, -1, 0], tex_coord: [1, 0] },
@@ -507,7 +507,7 @@ fn main() {
             .depth(gfx::state::Comparison::LessEqual, false)
             .blend(gfx::BlendPreset::Additive);
 
-        let light_batch: RefBatch<LightParams> = {
+        let light_batch: RefBatch<LightParams, gfx::GlResources> = {
             let program = device.link_program(LIGHT_VERTEX_SRC, LIGHT_FRAGMENT_SRC)
                                 .ok().expect("Failed to link program.");
 
@@ -515,7 +515,7 @@ fn main() {
                    .ok().expect("Failed to create batch")
         };
 
-        let emitter_batch: RefBatch<EmitterParams> = {
+        let emitter_batch: RefBatch<EmitterParams, gfx::GlResources> = {
             let program = device.link_program(EMITTER_VERTEX_SRC, EMITTER_FRAGMENT_SRC)
                                 .ok().expect("Failed to link program.");
 

--- a/examples/performance/main.rs
+++ b/examples/performance/main.rs
@@ -130,8 +130,10 @@ fn gfx_main(mut glfw: glfw::Glfw,
     };
 
     let mut graphics = gfx::Graphics::new(device);
-    let batch: RefBatch<Params> = graphics.make_batch(&program, &mesh, slice, &state)
-                                          .ok().expect("Failed to make batch");
+    let batch: RefBatch<Params, gfx::GlResources> = {
+        graphics.make_batch(&program, &mesh, slice, &state)
+                .ok().expect("Failed to make batch")
+    };
 
     while !window.should_close() {
         glfw.poll_events();

--- a/examples/terrain/main.rs
+++ b/examples/terrain/main.rs
@@ -163,8 +163,10 @@ fn main() {
     let state = gfx::DrawState::new().depth(gfx::state::Comparison::LessEqual, true);
 
     let mut graphics = gfx::Graphics::new(device);
-    let batch: RefBatch<Params> = graphics.make_batch(&program, &mesh, slice, &state)
-                                          .ok().expect("Failed to make batch.");
+    let batch: RefBatch<Params, gfx::GlResources> = {
+        graphics.make_batch(&program, &mesh, slice, &state)
+                .ok().expect("Failed to make batch.")
+    };
 
     let aspect = w as f32 / h as f32;
     let mut data = Params {

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -57,7 +57,7 @@ pub struct Graphics<D: device::Device> {
     /// Renderer front-end.
     pub renderer: Renderer<D>,
     /// Hidden batch context.
-    context: batch::Context,
+    context: batch::Context<GlResources>,
 }
 
 impl<D: device::Device> Graphics<D> {
@@ -77,7 +77,7 @@ impl<D: device::Device> Graphics<D> {
                       mesh: &Mesh<GlResources>,
                       slice: Slice<GlResources>,
                       state: &DrawState)
-                      -> Result<batch::RefBatch<T>, batch::BatchError> {
+                      -> Result<batch::RefBatch<T, GlResources>, batch::BatchError> {
         self.context.make_batch(program, mesh, slice, state)
     }
 
@@ -88,7 +88,7 @@ impl<D: device::Device> Graphics<D> {
 
     /// Draw a ref batch.
     pub fn draw<'a, T: shade::ShaderParam>(&'a mut self,
-                batch: &'a batch::RefBatch<T>, data: &'a T, frame: &Frame<GlResources>)
+                batch: &'a batch::RefBatch<T, GlResources>, data: &'a T, frame: &Frame<GlResources>)
                 -> Result<(), DrawError<batch::OutOfBounds>> {
         self.renderer.draw(&(batch, data, &self.context), frame)
     }

--- a/tests/shader_param.rs
+++ b/tests/shader_param.rs
@@ -36,7 +36,7 @@ struct TestParam {
 fn test_link_copy() {
     // testing if RefBatch is copyable
     fn _is_copy<T: Copy>(_t: T) {}
-    fn _ref_copy(batch: gfx::batch::RefBatch<TestParam>) {
+    fn _ref_copy(batch: gfx::batch::RefBatch<TestParam, gfx::GlResources>) {
         _is_copy(batch)
     }
 }
@@ -44,7 +44,7 @@ fn test_link_copy() {
 #[test]
 fn test_shader_param() {
     // testing if RefBatch can be constructed
-    let _ref: gfx::batch::RefBatch<TestParam>;
+    let _ref: gfx::batch::RefBatch<TestParam, gfx::GlResources>;
     // testing if OwnedBatch can be constructed
-    let _owned: gfx::batch::OwnedBatch<TestParam>;
+    let _owned: gfx::batch::OwnedBatch<TestParam, gfx::GlResources>;
 }


### PR DESCRIPTION
Working towards #416.

To truly decouple `render::batch` I need to parametrise `ParamValues`. I am having lifetime difficulties - I will explain elsewhere though.