### PR TITLE
Make device::gl_device crate fully self-contained

### DIFF
--- a/src/device/gl_device/draw.rs
+++ b/src/device/gl_device/draw.rs
@@ -16,9 +16,9 @@
 
 use std::slice;
 
-use {attrib, back, draw, target, tex, shade, state};
+use {attrib, draw, target, tex, shade, state};
 use {AttributeSlot, IndexType, InstanceCount, PrimitiveType, TextureSlot, UniformBlockIndex, UniformBufferSlot, VertexCount};
-use super::{ArrayBuffer, Buffer, FrameBuffer, Program, Surface, Texture};
+use super::{ArrayBuffer, Buffer, FrameBuffer, Program, Surface, Texture, GlResources};
 
 /// Serialized device command.
 #[derive(Copy, Debug)]
@@ -33,7 +33,7 @@ pub enum Command {
     BindTargetTexture(target::Access, target::Target, Texture, target::Level, Option<target::Layer>),
     BindUniformBlock(Program, UniformBufferSlot, UniformBlockIndex, Buffer),
     BindUniform(shade::Location, shade::UniformValue),
-    BindTexture(TextureSlot, tex::TextureKind, Texture, Option<::SamplerHandle<back::GlResources>>),
+    BindTexture(TextureSlot, tex::TextureKind, Texture, Option<::SamplerHandle<GlResources>>),
     SetDrawColorBuffers(usize),
     SetPrimitiveState(state::Primitive),
     SetViewport(target::Rect),
@@ -119,7 +119,7 @@ impl draw::CommandBuffer for CommandBuffer {
         self.buf.push(Command::BindUniform(loc, value));
     }
     fn bind_texture(&mut self, slot: ::TextureSlot, kind: ::tex::TextureKind,
-                    tex: Texture, sampler: Option<::SamplerHandle<back::GlResources>>) {
+                    tex: Texture, sampler: Option<::SamplerHandle<GlResources>>) {
         self.buf.push(Command::BindTexture(slot, kind, tex, sampler));
     }
 

--- a/src/device/gl_device/lib.rs
+++ b/src/device/gl_device/lib.rs
@@ -71,6 +71,16 @@ pub type Surface        = gl::types::GLuint;
 pub type Sampler        = gl::types::GLuint;
 pub type Texture        = gl::types::GLuint;
 
+/// A helper method to test `#[vertex_format]` without GL context
+//#[cfg(test)]
+pub fn make_dummy_buffer<T>() -> BufferHandle<GlResources, T> {
+    let info = ::BufferInfo {
+        usage: BufferUsage::Static,
+        size: 0,
+    };
+    BufferHandle::from_raw(::Handle(0, info))
+}
+
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum GlResources {}
 

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -23,9 +23,6 @@ extern crate log;
 extern crate bitflags;
 extern crate libc;
 
-// TODO: Remove these exports once `gl_device` becomes a separate crate.
-pub use self::gl_device as back;
-
 use std::fmt;
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -247,16 +244,6 @@ pub type SurfaceHandle<R: Resources> = Handle<<R as Resources>::Surface, tex::Su
 pub type TextureHandle<R: Resources> = Handle<<R as Resources>::Texture, tex::TextureInfo>;
 /// Sampler Handle
 pub type SamplerHandle<R: Resources> = Handle<<R as Resources>::Sampler, tex::SamplerInfo>;
-
-/// A helper method to test `#[vertex_format]` without GL context
-//#[cfg(test)]
-pub fn make_fake_buffer<T>() -> BufferHandle<back::GlResources, T> {
-    let info = BufferInfo {
-        usage: BufferUsage::Static,
-        size: 0,
-    };
-    BufferHandle::from_raw(Handle(0, info))
-}
 
 /// Treat a given slice as `&[u8]` for the given function call
 pub fn as_byte_slice<T>(slice: &[T]) -> &[u8] {

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -55,7 +55,7 @@ pub struct Graphics<D: device::Device> {
     /// Graphics device.
     pub device: D,
     /// Renderer front-end.
-    pub renderer: Renderer<D>,
+    pub renderer: Renderer<D::CommandBuffer>,
     /// Hidden batch context.
     context: batch::Context<D::Resources>,
 }

--- a/src/render/device_ext.rs
+++ b/src/render/device_ext.rs
@@ -60,7 +60,7 @@ impl<'a> ShaderSource<'a> {
 /// Backend extension trait for convenience methods
 pub trait DeviceExt: device::Device {
     /// Create a new renderer
-    fn create_renderer(&mut self) -> ::Renderer<Self>;
+    fn create_renderer(&mut self) -> ::Renderer<Self::CommandBuffer>;
     /// Create a new mesh from the given vertex data.
     /// Convenience function around `create_buffer` and `Mesh::from_format`.
     fn create_mesh<T>(&mut self, data: &[T]) -> Mesh<Self::Resources> where
@@ -75,7 +75,7 @@ pub trait DeviceExt: device::Device {
 }
 
 impl<D: device::Device> DeviceExt for D {
-    fn create_renderer(&mut self) -> ::Renderer<D> {
+    fn create_renderer(&mut self) -> ::Renderer<D::CommandBuffer> {
         ::Renderer {
             command_buffer: device::draw::CommandBuffer::new(),
             data_buffer: device::draw::DataBuffer::new(),

--- a/tests/vertex_format.rs
+++ b/tests/vertex_format.rs
@@ -49,8 +49,8 @@ fn test_vertex_format() {
     use secret_lib::gfx;
     use secret_lib::device;
 
-    let buf_vert = device::make_fake_buffer();
-    let buf_inst = device::make_fake_buffer();
+    let buf_vert = device::gl_device::make_dummy_buffer();
+    let buf_inst = device::gl_device::make_dummy_buffer();
     let mesh = gfx::Mesh::from_format_instanced::<MyVertex, MyInstance>(buf_vert, 0, buf_inst);
     let stride_vert = 34 as Stride;
     let stride_inst = 8 as Stride;


### PR DESCRIPTION
Closes #416.

Sorry for flip-flopping on the type parameter of `Renderer` - I previously changed it before `GlResources` was a 'thing'.