### PR TITLE
Split of referrence batches into Core/non-Core

### DIFF
--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -191,11 +191,19 @@ impl<R: Resources, T> BufferHandle<R, T> {
 }
 
 /// Raw (untyped) Buffer Handle
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(PartialEq, Debug)]
 pub struct RawBufferHandle<R: Resources>(
     <R as Resources>::Buffer,
     BufferInfo
 );
+
+impl<R: Resources> Copy for RawBufferHandle<R> {}
+
+impl<R: Resources> Clone for RawBufferHandle<R> {
+    fn clone(&self) -> RawBufferHandle<R> {
+        RawBufferHandle(self.0, self.1.clone())
+    }
+}
 
 impl<R: Resources> RawBufferHandle<R> {
     /// Creates a new raw buffer handle (used by device)
@@ -292,11 +300,19 @@ impl<R: Resources> SurfaceHandle<R> {
 }
 
 /// Texture Handle
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(PartialEq, Debug)]
 pub struct TextureHandle<R: Resources>(
     <R as Resources>::Texture,
     tex::TextureInfo,
 );
+
+impl<R: Resources> Copy for TextureHandle<R> {}
+
+impl<R: Resources> Clone for TextureHandle<R> {
+    fn clone(&self) -> TextureHandle<R> {
+        TextureHandle(self.0, self.1.clone())
+    }
+}
 
 impl<R: Resources> TextureHandle<R> {
     /// Creates a new texture (used by device)
@@ -311,11 +327,19 @@ impl<R: Resources> TextureHandle<R> {
 }
 
 /// Sampler Handle
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(PartialEq, Debug)]
 pub struct SamplerHandle<R: Resources>(
     <R as Resources>::Sampler,
     tex::SamplerInfo,
 );
+
+impl<R: Resources> Copy for SamplerHandle<R> {}
+
+impl<R: Resources> Clone for SamplerHandle<R> {
+    fn clone(&self) -> SamplerHandle<R> {
+        SamplerHandle(self.0, self.1.clone())
+    }
+}
 
 impl<R: Resources> SamplerHandle<R> {
     /// Creates a new sampler (used by device)
@@ -414,7 +438,7 @@ pub struct BufferInfo {
 
 /// Resources pertaining to a specific API.
 #[allow(missing_docs)]
-pub trait Resources: PhantomFn<Self> + Copy + Clone + PartialEq + fmt::Debug {
+pub trait Resources: PhantomFn<Self> + Clone + PartialEq + fmt::Debug {
     type Buffer:        Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
     type ArrayBuffer:   Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
     type Shader:        Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
@@ -423,17 +447,6 @@ pub trait Resources: PhantomFn<Self> + Copy + Clone + PartialEq + fmt::Debug {
     type Surface:       Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
     type Texture:       Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
     type Sampler:       Copy + Clone + fmt::Debug + PartialEq + Send + Sync;
-}
-
-impl Resources for () {
-    type Buffer = ();
-    type ArrayBuffer = ();
-    type Shader = ();
-    type Program = ();
-    type FrameBuffer = ();
-    type Surface = ();
-    type Texture = ();
-    type Sampler = ();
 }
 
 /// An interface for performing draw calls using a specific graphics API
@@ -561,6 +574,17 @@ mod test {
     use std::marker::PhantomData;
     use super::{BufferHandle, RawBufferHandle};
     use super::{BufferInfo, BufferUsage};
+
+    impl super::Resources for () {
+        type Buffer = ();
+        type ArrayBuffer = ();
+        type Shader = ();
+        type Program = ();
+        type FrameBuffer = ();
+        type Surface = ();
+        type Texture = ();
+        type Sampler = ();
+    }
 
     fn mock_buffer<T>(len: usize) -> BufferHandle<(), T> {
         BufferHandle {

--- a/src/device/lib.rs
+++ b/src/device/lib.rs
@@ -575,7 +575,9 @@ mod test {
     use super::{BufferHandle, RawBufferHandle};
     use super::{BufferInfo, BufferUsage};
 
-    impl super::Resources for () {
+    #[derive(Clone, Debug, PartialEq)]
+    enum TestResources {}
+    impl super::Resources for TestResources {
         type Buffer = ();
         type ArrayBuffer = ();
         type Shader = ();
@@ -586,7 +588,7 @@ mod test {
         type Sampler = ();
     }
 
-    fn mock_buffer<T>(len: usize) -> BufferHandle<(), T> {
+    fn mock_buffer<T>(len: usize) -> BufferHandle<TestResources, T> {
         BufferHandle {
             raw: unsafe { RawBufferHandle::new(
                 (),

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -70,6 +70,12 @@ impl<D: device::Device> std::ops::Deref for Graphics<D> {
     }
 }
 
+impl<D: device::Device> std::ops::DerefMut for Graphics<D> {
+    fn deref_mut(&mut self) -> &mut batch::Context<D::Resources> {
+        &mut self.context
+    }
+}
+
 impl<D: device::Device> Graphics<D> {
     /// Create a new graphics wrapper.
     pub fn new(mut device: D) -> Graphics<D> {

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -99,9 +99,9 @@ impl<D: device::Device> Graphics<D> {
         self.renderer.draw(&(batch, &self.context), frame)
     }
 
-    /// Draw a `RefCore` batch.
+    /// Draw a `CoreBatch` batch.
     pub fn draw_core<'a, T: shade::ShaderParam<Resources = D::Resources>>(&'a mut self,
-                     core: &'a batch::RefCore<T>, slice: &'a Slice<D::Resources>,
+                     core: &'a batch::CoreBatch<T>, slice: &'a Slice<D::Resources>,
                      params: &'a T, frame: &Frame<D::Resources>)
                      -> Result<(), DrawError<batch::OutOfBounds>> {
         self.renderer.draw(&self.context.bind(core, slice, params), frame)

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -86,11 +86,19 @@ impl<D: device::Device> Graphics<D> {
         self.renderer.clear(data, mask, frame)
     }
 
-    /// Draw a ref batch.
+    /// Draw a `RefBatch` batch.
     pub fn draw<'a, T: shade::ShaderParam<Resources = D::Resources>>(&'a mut self,
                 batch: &'a batch::RefBatch<T>, frame: &Frame<D::Resources>)
                 -> Result<(), DrawError<batch::OutOfBounds>> {
         self.renderer.draw(&(batch, &self.context), frame)
+    }
+
+    /// Draw a `RefCore` batch.
+    pub fn draw_core<'a, T: shade::ShaderParam<Resources = D::Resources>>(&'a mut self,
+                     core: &'a batch::RefCore<T>, slice: &'a Slice<D::Resources>,
+                     params: &'a T, frame: &Frame<D::Resources>)
+                     -> Result<(), DrawError<batch::OutOfBounds>> {
+        self.renderer.draw(&self.context.bind(core, slice, params), frame)
     }
 
     /// Submit the internal command buffer and reset for the next frame.

--- a/src/gfx/lib.rs
+++ b/src/gfx/lib.rs
@@ -62,6 +62,14 @@ pub struct Graphics<D: device::Device> {
     context: batch::Context<D::Resources>,
 }
 
+impl<D: device::Device> std::ops::Deref for Graphics<D> {
+    type Target = batch::Context<D::Resources>;
+
+    fn deref(&self) -> &batch::Context<D::Resources> {
+        &self.context
+    }
+}
+
 impl<D: device::Device> Graphics<D> {
     /// Create a new graphics wrapper.
     pub fn new(mut device: D) -> Graphics<D> {
@@ -73,16 +81,6 @@ impl<D: device::Device> Graphics<D> {
         }
     }
 
-    /// Create a new ref batch.
-    pub fn make_batch<T: shade::ShaderParam<Resources = D::Resources>>(&mut self,
-                      program: &ProgramHandle<D::Resources>,
-                      mesh: &Mesh<D::Resources>,
-                      slice: Slice<D::Resources>,
-                      state: &DrawState)
-                      -> Result<batch::RefBatch<T>, batch::Error> {
-        self.context.make_batch(program, mesh, slice, state)
-    }
-
     /// Clear the `Frame` as the `ClearData` specifies.
     pub fn clear(&mut self, data: ClearData, mask: Mask, frame: &Frame<D::Resources>) {
         self.renderer.clear(data, mask, frame)
@@ -90,9 +88,9 @@ impl<D: device::Device> Graphics<D> {
 
     /// Draw a ref batch.
     pub fn draw<'a, T: shade::ShaderParam<Resources = D::Resources>>(&'a mut self,
-                batch: &'a batch::RefBatch<T>, data: &'a T, frame: &Frame<D::Resources>)
+                batch: &'a batch::RefBatch<T>, frame: &Frame<D::Resources>)
                 -> Result<(), DrawError<batch::OutOfBounds>> {
-        self.renderer.draw(&self.context.bind(batch, data), frame)
+        self.renderer.draw(&(batch, &self.context), frame)
     }
 
     /// Submit the internal command buffer and reset for the next frame.

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -422,13 +422,13 @@ impl<R: Resources> Context<R> {
                       program: &ProgramHandle<R>,
                       params: T,
                       mesh: &mesh::Mesh<R>,
-                      slice: &mesh::Slice<R>,
+                      slice: mesh::Slice<R>,
                       state: &DrawState)
                       -> Result<RefBatch<T>, Error> {
         self.make(program, Some(&params), mesh, state)
             .map(|core| RefBatch {
             core: core,
-            slice: slice.clone(),
+            slice: slice,
             params: params,
         })
     }

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -17,9 +17,10 @@
 //! `RefBatch` and `OwnedBatch` implementations.
 
 use std::fmt;
-use std::num::from_uint;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
+use std::num::from_uint;
+use std::ops::Deref;
 use draw_state::DrawState;
 
 use device::{Resources, PrimitiveType, ProgramHandle};
@@ -236,65 +237,112 @@ impl<T: Clone + PartialEq> Array<T> {
 }
 
 
-/// Ref batch - copyable and smaller, but depends on the `Context`.
+/// Referrenced core - a minimal sealed batch that depends on `Context`.
 /// It has references to the resources (mesh, program, state), that are held
 /// by the context that created the batch, so these have to be used together.
-pub struct RefBatch<T: ShaderParam> {
+pub struct RefCore<T: ShaderParam> {
     mesh_id: Id<mesh::Mesh<T::Resources>>,
     mesh_link: mesh::Link,
-    /// Mesh slice
-    pub slice: mesh::Slice<T::Resources>,
     program_id: Id<ProgramHandle<T::Resources>>,
     param_link: T::Link,
     state_id: Id<DrawState>,
 }
 
-impl<T: ShaderParam> Copy for RefBatch<T> where T::Link: Copy {}
+impl<T: ShaderParam> Copy for RefCore<T> where T::Link: Copy {}
 
-impl<T: ShaderParam> fmt::Debug for RefBatch<T> {
+impl<T: ShaderParam> fmt::Debug for RefCore<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RefBatch(mesh: {:?}, slice: {:?}, program: {:?}, state: {:?})",
-            self.mesh_id, self.slice, self.program_id, self.state_id)
+        write!(f, "RefCore(mesh: {:?}, program: {:?}, state: {:?})",
+            self.mesh_id, self.program_id, self.state_id)
     }
 }
 
-impl<T: ShaderParam> PartialEq for RefBatch<T> {
-    fn eq(&self, other: &RefBatch<T>) -> bool {
+impl<T: ShaderParam> PartialEq for RefCore<T> {
+    fn eq(&self, other: &RefCore<T>) -> bool {
         self.program_id == other.program_id &&
         self.state_id == other.state_id &&
         self.mesh_id == other.mesh_id
     }
 }
 
-impl<T: ShaderParam> Eq for RefBatch<T> {}
+impl<T: ShaderParam> Eq for RefCore<T> {}
 
-impl<T: ShaderParam> PartialOrd for RefBatch<T> {
-    fn partial_cmp(&self, other: &RefBatch<T>) -> Option<Ordering> {
+impl<T: ShaderParam> PartialOrd for RefCore<T> {
+    fn partial_cmp(&self, other: &RefCore<T>) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T: ShaderParam> Ord for RefBatch<T> {
-    fn cmp(&self, other: &RefBatch<T>) -> Ordering {
+impl<T: ShaderParam> Ord for RefCore<T> {
+    fn cmp(&self, other: &RefCore<T>) -> Ordering {
         (&self.program_id, &self.state_id, &self.mesh_id).cmp(
         &(&other.program_id, &other.state_id, &other.mesh_id))
     }
 }
 
-impl<T: ShaderParam> RefBatch<T> {
+impl<T: ShaderParam> RefCore<T> {
     /// Compare meshes by Id
-    pub fn cmp_mesh(&self, other: &RefBatch<T>) -> Ordering {
+    pub fn cmp_mesh(&self, other: &RefCore<T>) -> Ordering {
         self.mesh_id.cmp(&other.mesh_id)
     }
     /// Compare programs by Id
-    pub fn cmp_program(&self, other: &RefBatch<T>) -> Ordering {
+    pub fn cmp_program(&self, other: &RefCore<T>) -> Ordering {
         self.program_id.cmp(&other.program_id)
     }
     /// Compare draw states by Id
-    pub fn cmp_state(&self, other: &RefBatch<T>) -> Ordering {
+    pub fn cmp_state(&self, other: &RefCore<T>) -> Ordering {
         self.state_id.cmp(&other.state_id)
     }
 }
+
+/// A `RefCore` completed by a slice, shader parameters, and a context
+/// Implements `Batch` thus can be drawn.
+/// It is meant to be a struct, but we have lots of lifetime issues
+/// with associated resources, binding which looks nasty (#614)
+pub type RefCoreFull<'a, T: ShaderParam> = (
+    &'a RefCore<T>,
+    &'a mesh::Slice<T::Resources>,
+    &'a T,
+    &'a Context<T::Resources>
+);
+
+
+/// An expanded version of the `RefCore`, carrying the parameters and
+/// the mesh slice with it, publicly mutable.
+pub struct RefBatch<T: ShaderParam> {
+    /// Core of the batch
+    pub core: RefCore<T>,
+    /// Mesh slice
+    pub slice: mesh::Slice<T::Resources>,
+    /// Shader parameter values
+    pub params: T,
+}
+
+impl<T: ShaderParam> Deref for RefBatch<T> {
+    type Target = RefCore<T>;
+
+    fn deref(&self) -> &RefCore<T> {
+        &self.core
+    }
+}
+
+impl<T: ShaderParam + Clone> Clone for RefBatch<T> where T::Link: Copy {
+    fn clone(&self) -> RefBatch<T> {
+        RefBatch {
+            core: self.core,
+            slice: self.slice.clone(),
+            params: self.params.clone(),
+        }
+    }
+}
+
+impl<T: ShaderParam + fmt::Debug> fmt::Debug for RefBatch<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RefBatch(core: {:?}, slice: {:?}, params: {:?}",
+            self.core, self.slice, self.params)
+    }
+}
+
 
 /// Factory of ref batches, required to always be used with them.
 pub struct Context<R: Resources> {
@@ -303,13 +351,12 @@ pub struct Context<R: Resources> {
     states: Array<DrawState>,
 }
 
-/// A RefBatch completed by the shader parameters and a context
+/// A `RefBatch` completed by the a batch context
 /// Implements `Batch` thus can be drawn.
 /// It is meant to be a struct, but we have lots of lifetime issues
 /// with associated resources, binding which looks nasty (#614)
 pub type RefBatchFull<'a, T: ShaderParam> = (
     &'a RefBatch<T>,
-    &'a T,
     &'a Context<T::Resources>
 );
 
@@ -325,13 +372,12 @@ impl<R: Resources> Context<R> {
 }
 
 impl<R: Resources> Context<R> {
-    /// Produce a new ref batch
-    pub fn make_batch<T: ShaderParam<Resources = R>>(&mut self,
-                      program: &ProgramHandle<R>,
-                      mesh: &mesh::Mesh<R>,
-                      slice: mesh::Slice<R>,
-                      state: &DrawState)
-                      -> Result<RefBatch<T>, Error> {
+    /// Produce a new `RefCore`
+    pub fn make_core<T: ShaderParam<Resources = R>>(&mut self,
+                     program: &ProgramHandle<R>,
+                     mesh: &mesh::Mesh<R>,
+                     state: &DrawState)
+                     -> Result<RefCore<T>, Error> {
         let mesh_link = match mesh::Link::new(mesh, program.get_info()) {
             Ok(l) => l,
             Err(e) => return Err(Error::Mesh(e)),
@@ -353,20 +399,63 @@ impl<R: Resources> Context<R> {
             None => return Err(Error::ContextFull),
         };
 
-        Ok(RefBatch {
+        Ok(RefCore {
             mesh_id: mesh_id,
             mesh_link: mesh_link,
-            slice: slice,
             program_id: program_id,
             param_link: link,
             state_id: state_id,
         })
     }
 
-    /// Complete a RefBatch temporarily by turning it into RefBatchFull
+    /// Produce a new `RefBatch`
+    pub fn make_batch<T: ShaderParam<Resources = R>>(&mut self,
+                      program: &ProgramHandle<R>,
+                      params: T,
+                      mesh: &mesh::Mesh<R>,
+                      slice: &mesh::Slice<R>,
+                      state: &DrawState)
+                      -> Result<RefBatch<T>, Error> {
+        self.make_core(program, mesh, state).map(|core| RefBatch {
+            core: core,
+            slice: slice.clone(),
+            params: params,
+        })
+    }
+
+    /// Complete a RefCore temporarily by turning it into RefCoreFull
     pub fn bind<'a, T: ShaderParam<Resources = R> + 'a>(&'a self,
-                 batch: &'a RefBatch<T>, data: &'a T) -> RefBatchFull<'a, T> {
-        (batch, data, self)
+                 core: &'a RefCore<T>, slice: &'a mesh::Slice<R>,
+                 params: &'a T) -> RefCoreFull<'a, T> {
+        (core, slice, params, self)
+    }
+
+    /// Get data from a batch in the format required for `Batch`
+    pub fn get_data<'a, T: ShaderParam<Resources = R> + 'a>(&'a self,
+                    core: &RefCore<T>, slice: &'a mesh::Slice<R>)
+                    -> Result<BatchData<'a, T::Resources>, OutOfBounds> {
+        Ok((try!(self.meshes.get(core.mesh_id)),
+            core.mesh_link.to_iter(),
+            slice,
+            try!(self.states.get(core.state_id))
+        ))
+    }
+}
+
+impl<'a, T: ShaderParam + 'a> Batch for RefCoreFull<'a, T> {
+    type Resources = T::Resources;
+    type Error = OutOfBounds;
+
+    fn get_data(&self) -> Result<BatchData<T::Resources>, OutOfBounds> {
+        let (b, slice, _, ctx) = *self;
+        ctx.get_data(b, slice)
+    }
+
+    fn fill_params(&self, values: ::shade::ParamValues<T::Resources>)
+                   -> Result<&ProgramHandle<T::Resources>, OutOfBounds> {
+        let (b, _, data, ctx) = *self;
+        data.fill_params(&b.param_link, values);
+        ctx.programs.get(b.program_id)
     }
 }
 
@@ -375,18 +464,14 @@ impl<'a, T: ShaderParam + 'a> Batch for RefBatchFull<'a, T> {
     type Error = OutOfBounds;
 
     fn get_data(&self) -> Result<BatchData<T::Resources>, OutOfBounds> {
-        let (b, _, ctx) = *self;
-        Ok((try!(ctx.meshes.get(b.mesh_id)),
-            b.mesh_link.to_iter(),
-            &b.slice,
-            try!(ctx.states.get(b.state_id))
-        ))
+        let (b, ctx) = *self;
+        ctx.get_data(&b.core, &b.slice)
     }
 
     fn fill_params(&self, values: ::shade::ParamValues<T::Resources>)
                    -> Result<&ProgramHandle<T::Resources>, OutOfBounds> {
-        let (b, data, ctx) = *self;
-        data.fill_params(&b.param_link, values);
-        ctx.programs.get(b.program_id)
+        let (b, ctx) = *self;
+        b.params.fill_params(&b.core.param_link, values);
+        ctx.programs.get(b.core.program_id)
     }
 }

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -100,7 +100,7 @@ impl<R: Resources> Mesh<R> {
 /// The `prim_type` defines how the mesh contents are interpreted.
 /// For example,  `Point` typed vertex slice can be used to do shape
 /// blending, while still rendereing it as an indexed `TriangleList`.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Slice<R: Resources> {
     /// Start index of vertices to draw.
     pub start: VertexCount,
@@ -113,7 +113,7 @@ pub struct Slice<R: Resources> {
 }
 
 /// Source of vertex ordering for a slice
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SliceKind<R: Resources> {
     /// Render vertex data directly from the `Mesh`'s buffer.
     Vertex,
@@ -158,7 +158,7 @@ impl<R: Resources> ToSlice<R> for BufferHandle<R, u8> {
             start: 0,
             end: self.len() as VertexCount,
             prim_type: ty,
-            kind: SliceKind::Index8(*self, 0)
+            kind: SliceKind::Index8(self.clone(), 0)
         }
     }
 }
@@ -170,7 +170,7 @@ impl<R: Resources> ToSlice<R> for BufferHandle<R, u16> {
             start: 0,
             end: self.len() as VertexCount,
             prim_type: ty,
-            kind: SliceKind::Index16(*self, 0)
+            kind: SliceKind::Index16(self.clone(), 0)
         }
     }
 }
@@ -182,7 +182,7 @@ impl<R: Resources> ToSlice<R> for BufferHandle<R, u32> {
             start: 0,
             end: self.len() as VertexCount,
             prim_type: ty,
-            kind: SliceKind::Index32(*self, 0)
+            kind: SliceKind::Index32(self.clone(), 0)
         }
     }
 }

--- a/src/render/target.rs
+++ b/src/render/target.rs
@@ -18,7 +18,7 @@ use device;
 use device::Resources;
 use draw_state::target::{Layer, Level, Mask};
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 /// A single buffer that can be bound to a render target.
 pub enum Plane<R: Resources> {
     /// Render to a `Surface` (corresponds to a renderbuffer in GL).


### PR DESCRIPTION
(This is a breaking change, please review carefully)

I noticed a couple of things that weren't sound:
  1. `RefBatch` carried a publicly accessible `slice`, while not carrying the parameters. The reason for the former was "convenience" (IIRC), the reason for the latter was "just because we can". Hence, this type was neither complete nor minimal.
  2. A lot of applications tend to keep a parameter structure together with a `RefBatch`. They are often seen together, and that wasn't convenient to do.

As a solution, I made a `RefCore` batch that only carries minimal (for safety) sealed data, nothing is available to public. The `RefBatch` now is rather open - it carries the core as well as a slice (like it used to) and a parameter structure, all mutable by public.

The idea is - `RefCore` to be used for maximum flexibility, like creating a batch when not yet having a parameter structure at hands, or using it with multiple parameters/slices. While `RefBatch` is just a convenient thing to have. The maintenance cost is minimal, since they are re-using lots of code.

`RefBatch` is also nice for ergonomic reasons - you can create a batch with type inference.