### PR TITLE
Resource tracking and destruction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.2.1"
+version = "0.2.2"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -96,8 +96,7 @@ pub trait CommandBuffer<R: Resources> {
     /// Unbind any surface from the specified target slot
     fn unbind_target(&mut self, Access, Target);
     /// Bind a surface to the specified target slot
-    fn bind_target_surface(&mut self, Access, Target,
-                           R::Surface);
+    fn bind_target_surface(&mut self, Access, Target, R::Surface);
     /// Bind a level of the texture to the specified target slot
     fn bind_target_texture(&mut self, Access, Target, R::Texture,
                            target::Level, Option<target::Layer>);

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -108,7 +108,7 @@ pub trait CommandBuffer<R: Resources> {
     fn bind_uniform(&mut self, shade::Location, shade::UniformValue);
     /// Bind a texture
     fn bind_texture(&mut self, super::TextureSlot, tex::TextureKind,
-                    R::Texture, Option<::SamplerHandle<R>>);
+                    R::Texture, Option<(R::Sampler, tex::SamplerInfo)>);
     /// Select, which color buffers are going to be targetted by the shader
     fn set_draw_color_buffers(&mut self, usize);
     /// Set primitive topology

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -27,7 +27,7 @@ use super::{shade, tex, Resources, BufferInfo};
 /// referencing them both by the Factory on resource creation
 /// and the Renderer during CommandBuffer population.
 #[allow(missing_docs)]
-pub struct RefStorage<R: Resources> {
+pub struct Manager<R: Resources> {
     buffers: Vec<Arc<R::Buffer>>,
     array_buffers: Vec<Arc<R::ArrayBuffer>>,
     shaders: Vec<Arc<R::Shader>>,
@@ -36,7 +36,7 @@ pub struct RefStorage<R: Resources> {
 }
 
 /// A service trait to be used by the device implementation
-pub trait HandleFactory<R: Resources> {
+pub trait Producer<R: Resources> {
     /// Create a new raw buffer handle
     fn new_buffer(&mut self, R::Buffer, BufferInfo) -> RawBuffer<R>;
     /// Create a new array buffer
@@ -47,7 +47,7 @@ pub trait HandleFactory<R: Resources> {
     fn new_program(&mut self, R::Program, shade::ProgramInfo) -> Program<R>;
 }
 
-impl<R: Resources> HandleFactory<R> for RefStorage<R> {
+impl<R: Resources> Producer<R> for Manager<R> {
     fn new_buffer(&mut self, name: R::Buffer, info: BufferInfo) -> RawBuffer<R> {
         let r = Arc::new(name);
         self.buffers.push(r.clone());
@@ -73,10 +73,10 @@ impl<R: Resources> HandleFactory<R> for RefStorage<R> {
     }
 }
 
-impl<R: Resources> RefStorage<R> {
+impl<R: Resources> Manager<R> {
     /// Create a new reference storage
-    pub fn new() -> RefStorage<R> {
-        RefStorage {
+    pub fn new() -> Manager<R> {
+        Manager {
             buffers: Vec::new(),
             array_buffers: Vec::new(),
             shaders: Vec::new(),
@@ -87,8 +87,8 @@ impl<R: Resources> RefStorage<R> {
     pub fn reset(&mut self) {
         self.buffers.clear();
     }
-    /// Extend with references from another buffer
-    pub fn extend(&mut self, other: &RefStorage<R>) {
+    /// Extend with references from another manager
+    pub fn extend(&mut self, other: &Manager<R>) {
         self.buffers.extend(other.buffers.iter().map(|b| b.clone()));
     }
     /// Reference a buffer

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -287,6 +287,13 @@ impl<R: Resources> Manager<R> {
     /// Clear all references
     pub fn clear(&mut self) {
         self.buffers.clear();
+        self.array_buffers.clear();
+        self.shaders.clear();
+        self.programs.clear();
+        self.frame_buffers.clear();
+        self.surfaces.clear();
+        self.textures.clear();
+        self.samplers.clear();
     }
     /// Extend with all references of another handle manager
     pub fn extend(&mut self, other: &Manager<R>) {

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -175,17 +175,6 @@ pub trait Factory<R: Resources> {
     /// Return the framebuffer handle for the screen.
     fn get_main_frame_buffer(&self) -> handle::FrameBuffer<R>;
 
-    // resource deletion
-    fn delete_buffer_raw(&mut self, buf: handle::Buffer<R, ()>);
-    fn delete_buffer<T>(&mut self, buf: handle::Buffer<R, T>) {
-        self.delete_buffer_raw(buf.cast());
-    }
-    fn delete_shader(&mut self, handle::Shader<R>);
-    fn delete_program(&mut self, handle::Program<R>);
-    fn delete_surface(&mut self, handle::Surface<R>);
-    fn delete_texture(&mut self, handle::Texture<R>);
-    fn delete_sampler(&mut self, handle::Sampler<R>);
-
     /// Update the information stored in a specific buffer
     fn update_buffer_raw(&mut self, buf: handle::Buffer<R, ()>, data: &[u8],
                          offset_bytes: usize);
@@ -208,6 +197,8 @@ pub trait Factory<R: Resources> {
         self.update_texture_raw(tex, img, as_byte_slice(data))
     }
     fn generate_mipmap(&mut self, tex: &handle::Texture<R>);
+
+    fn cleanup(&mut self);
 }
 
 
@@ -223,5 +214,11 @@ pub trait Device {
     /// Reset all the states to disabled/default
     fn reset_state(&mut self);
     /// Submit a command buffer for execution
-    fn submit(&mut self, buffer: (&Self::CommandBuffer, &draw::DataBuffer));
+    fn submit(&mut self, buffer: (
+        &Self::CommandBuffer,
+        &draw::DataBuffer,
+        &handle::RefStorage<Self::Resources>
+    ));
+    /// Finish processing the current frame
+    fn present(&mut self);
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -198,6 +198,7 @@ pub trait Factory<R: Resources> {
     }
     fn generate_mipmap(&mut self, tex: &handle::Texture<R>);
 
+    /// Clean up all unreferenced resources
     fn cleanup(&mut self);
 }
 

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -154,13 +154,13 @@ pub trait Factory<R: Resources> {
     /// Associated mapper type
     type Mapper: Clone + mapping::Raw;
     // resource creation
-    fn create_buffer_raw(&mut self, size: usize, usage: BufferUsage) -> handle::Buffer<R, ()>;
+    fn create_buffer_raw(&mut self, size: usize, usage: BufferUsage) -> handle::RawBuffer<R>;
     fn create_buffer<T>(&mut self, num: usize, usage: BufferUsage) -> handle::Buffer<R, T> {
-        self.create_buffer_raw(num * mem::size_of::<T>(), usage).cast()
+        handle::Buffer::from_raw(self.create_buffer_raw(num * mem::size_of::<T>(), usage))
     }
-    fn create_buffer_static_raw(&mut self, data: &[u8]) -> handle::Buffer<R, ()>;
+    fn create_buffer_static_raw(&mut self, data: &[u8]) -> handle::RawBuffer<R>;
     fn create_buffer_static<T: Copy>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
-        self.create_buffer_static_raw(as_byte_slice(data)).cast()
+        handle::Buffer::from_raw(self.create_buffer_static_raw(as_byte_slice(data)))
     }
     fn create_array_buffer(&mut self) -> Result<handle::ArrayBuffer<R>, ()>;
     fn create_shader(&mut self, stage: shade::Stage, code: &[u8]) ->
@@ -168,35 +168,32 @@ pub trait Factory<R: Resources> {
     fn create_program(&mut self, shaders: &[handle::Shader<R>], targets: Option<&[&str]>)
                       -> Result<handle::Program<R>, ()>;
     fn create_frame_buffer(&mut self) -> handle::FrameBuffer<R>;
-    fn create_surface(&mut self, info: tex::SurfaceInfo) -> Result<handle::Surface<R>, tex::SurfaceError>;
-    fn create_texture(&mut self, info: tex::TextureInfo) -> Result<handle::Texture<R>, tex::TextureError>;
-    fn create_sampler(&mut self, info: tex::SamplerInfo) -> handle::Sampler<R>;
+    fn create_surface(&mut self, tex::SurfaceInfo) -> Result<handle::Surface<R>, tex::SurfaceError>;
+    fn create_texture(&mut self, tex::TextureInfo) -> Result<handle::Texture<R>, tex::TextureError>;
+    fn create_sampler(&mut self, tex::SamplerInfo) -> handle::Sampler<R>;
 
     /// Return the framebuffer handle for the screen.
     fn get_main_frame_buffer(&self) -> handle::FrameBuffer<R>;
 
     /// Update the information stored in a specific buffer
-    fn update_buffer_raw(&mut self, buf: handle::Buffer<R, ()>, data: &[u8],
-                         offset_bytes: usize);
-    fn update_buffer<T: Copy>(&mut self, buf: handle::Buffer<R, T>, data: &[T],
-                     offset_elements: usize) {
-        self.update_buffer_raw(buf.cast(), as_byte_slice(data), mem::size_of::<T>() * offset_elements)
+    fn update_buffer_raw(&mut self, buf: &handle::RawBuffer<R>, data: &[u8], offset_bytes: usize);
+    fn update_buffer<T: Copy>(&mut self, buf: &handle::Buffer<R, T>, data: &[T], offset_elements: usize) {
+        self.update_buffer_raw(buf.raw(), as_byte_slice(data), mem::size_of::<T>() * offset_elements)
     }
-    fn map_buffer_raw(&mut self, buf: handle::Buffer<R, ()>, access: MapAccess) -> Self::Mapper;
-    fn unmap_buffer_raw(&mut self, map: Self::Mapper);
-    fn map_buffer_readable<T: Copy>(&mut self, buf: handle::Buffer<R, T>) -> mapping::Readable<T, R, Self>;
-    fn map_buffer_writable<T: Copy>(&mut self, buf: handle::Buffer<R, T>) -> mapping::Writable<T, R, Self>;
-    fn map_buffer_rw<T: Copy>(&mut self, buf: handle::Buffer<R, T>) -> mapping::RW<T, R, Self>;
+    fn map_buffer_raw(&mut self, &handle::RawBuffer<R>, MapAccess) -> Self::Mapper;
+    fn unmap_buffer_raw(&mut self, Self::Mapper);
+    fn map_buffer_readable<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::Readable<T, R, Self>;
+    fn map_buffer_writable<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::Writable<T, R, Self>;
+    fn map_buffer_rw<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::RW<T, R, Self>;
 
     /// Update the information stored in a texture
-    fn update_texture_raw(&mut self, tex: &handle::Texture<R>, img: &tex::ImageInfo,
-                          data: &[u8]) -> Result<(), tex::TextureError>;
-    fn update_texture<T: Copy>(&mut self, tex: &handle::Texture<R>,
-                      img: &tex::ImageInfo, data: &[T])
+    fn update_texture_raw(&mut self, tex: &handle::Texture<R>, img: &tex::ImageInfo, data: &[u8])
+                          -> Result<(), tex::TextureError>;
+    fn update_texture<T: Copy>(&mut self, tex: &handle::Texture<R>, img: &tex::ImageInfo, data: &[T])
                       -> Result<(), tex::TextureError> {
         self.update_texture_raw(tex, img, as_byte_slice(data))
     }
-    fn generate_mipmap(&mut self, tex: &handle::Texture<R>);
+    fn generate_mipmap(&mut self, &handle::Texture<R>);
 
     /// Clean up all unreferenced resources
     fn cleanup(&mut self);
@@ -212,14 +209,17 @@ pub trait Device {
 
     /// Returns the capabilities available to the specific API implementation
     fn get_capabilities<'a>(&'a self) -> &'a Capabilities;
+
     /// Reset all the states to disabled/default
     fn reset_state(&mut self);
+
     /// Submit a command buffer for execution
-    fn submit(&mut self, buffer: (
+    fn submit(&mut self, (
         &Self::CommandBuffer,
         &draw::DataBuffer,
         &handle::Manager<Self::Resources>
     ));
-    /// Finish processing the current frame
-    fn present(&mut self);
+
+    /// Notify the finished frame
+    fn after_frame(&mut self);
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -217,7 +217,7 @@ pub trait Device {
     fn submit(&mut self, buffer: (
         &Self::CommandBuffer,
         &draw::DataBuffer,
-        &handle::RefStorage<Self::Resources>
+        &handle::Manager<Self::Resources>
     ));
     /// Finish processing the current frame
     fn present(&mut self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,9 @@
 //! An efficient, low-level, bindless graphics API for Rust. See [the
 //! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
 
-#![feature(core, libc, unsafe_destructor)]
+#![feature(alloc, core, libc, unsafe_destructor)]
 
+extern crate alloc;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -19,7 +19,6 @@
 use std::fmt;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
-use std::num::from_uint;
 use std::ops::Deref;
 use draw_state::DrawState;
 
@@ -226,10 +225,11 @@ impl<T> Array<T> {
 
 impl<T: Clone + PartialEq> Array<T> {
     fn find_or_insert(&mut self, value: &T) -> Option<Id<T>> {
+        use std::num::from_u32;
         match self.data.iter().position(|v| v == value) {
-            Some(i) => from_uint::<Index>(i).map(|id| Id(id, PhantomData)),
+            Some(i) => from_u32(i as u32).map(|id| Id(id, PhantomData)),
             None => {
-                from_uint::<Index>(self.data.len()).map(|id| {
+                from_u32(self.data.len() as u32).map(|id| {
                     self.data.push(value.clone());
                     Id(id, PhantomData)
                 })

--- a/src/render/ext/device.rs
+++ b/src/render/ext/device.rs
@@ -93,7 +93,7 @@ impl<
         ::Renderer {
             command_buffer: device::draw::CommandBuffer::new(),
             data_buffer: device::draw::DataBuffer::new(),
-            handler: device::handle::Manager::new(),
+            handles: device::handle::Manager::new(),
             common_array_buffer: self.create_array_buffer(),
             draw_frame_buffer: self.create_frame_buffer(),
             read_frame_buffer: self.create_frame_buffer(),

--- a/src/render/ext/device.rs
+++ b/src/render/ext/device.rs
@@ -93,6 +93,7 @@ impl<
         ::Renderer {
             command_buffer: device::draw::CommandBuffer::new(),
             data_buffer: device::draw::DataBuffer::new(),
+            ref_storage: device::handle::RefStorage::new(),
             common_array_buffer: self.create_array_buffer(),
             draw_frame_buffer: self.create_frame_buffer(),
             read_frame_buffer: self.create_frame_buffer(),

--- a/src/render/ext/device.rs
+++ b/src/render/ext/device.rs
@@ -93,7 +93,7 @@ impl<
         ::Renderer {
             command_buffer: device::draw::CommandBuffer::new(),
             data_buffer: device::draw::DataBuffer::new(),
-            ref_storage: device::handle::RefStorage::new(),
+            handler: device::handle::Manager::new(),
             common_array_buffer: self.create_array_buffer(),
             draw_frame_buffer: self.create_frame_buffer(),
             read_frame_buffer: self.create_frame_buffer(),

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -68,7 +68,7 @@ impl<R: Resources> Mesh<R> {
                        -> Mesh<R> {
         Mesh {
             num_vertices: nv,
-            attributes: VertexFormat::generate(None::<&V>, buf.raw()),
+            attributes: VertexFormat::generate(None::<&V>, buf.raw().clone()),
         }
     }
 
@@ -77,8 +77,8 @@ impl<R: Resources> Mesh<R> {
                                  buf: BufferHandle<R, V>,
                                  nv: device::VertexCount,
                                  inst: BufferHandle<R, U>) -> Mesh<R> {
-        let per_vertex   = VertexFormat::generate(None::<&V>, buf.raw());
-        let per_instance = VertexFormat::generate(None::<&U>, inst.raw());
+        let per_vertex   = VertexFormat::generate(None::<&V>, buf.raw().clone());
+        let per_instance = VertexFormat::generate(None::<&U>, inst.raw().clone());
 
         let mut attributes = per_vertex;
         for mut at in per_instance.into_iter() {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -152,6 +152,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     pub fn reset(&mut self) {
         self.command_buffer.clear();
         self.data_buffer.clear();
+        self.handler.clear();
         self.render_state = RenderState::new();
     }
 
@@ -288,12 +289,14 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
         if frame.is_default() {
             if self.render_state.is_frame_buffer_set {
                 // binding the default FBO, not touching our common one
-                self.command_buffer.bind_frame_buffer(Access::Draw, self.default_frame_buffer.get_name());
+                self.command_buffer.bind_frame_buffer(Access::Draw,
+                    self.handler.ref_frame_buffer(&self.default_frame_buffer));
                 self.render_state.is_frame_buffer_set = false;
             }
         } else {
             if !self.render_state.is_frame_buffer_set {
-                self.command_buffer.bind_frame_buffer(Access::Draw, self.draw_frame_buffer.get_name());
+                self.command_buffer.bind_frame_buffer(Access::Draw,
+                    self.handler.ref_frame_buffer(&self.draw_frame_buffer));
                 self.render_state.is_frame_buffer_set = true;
             }
             // cut off excess color planes
@@ -332,7 +335,8 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     }
 
     fn bind_read_frame(&mut self, frame: &target::Frame<R>) {
-        self.command_buffer.bind_frame_buffer(Access::Read, self.read_frame_buffer.get_name());
+        self.command_buffer.bind_frame_buffer(Access::Read,
+            self.handler.ref_frame_buffer(&self.read_frame_buffer));
         // color
         if frame.colors.is_empty() {
             self.command_buffer.unbind_target(Access::Read, Target::Color(0));

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -427,7 +427,9 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
         if !self.render_state.is_array_buffer_set {
             // It's Ok if the array buffer is not supported. We can just ignore it.
             match self.common_array_buffer {
-                Ok(ref ab) => self.command_buffer.bind_array_buffer(ab.get_name()),
+                Ok(ref ab) => self.command_buffer.bind_array_buffer(
+                    self.ref_storage.ref_array_buffer(ab)
+                ),
                 Err(()) => (),
             };
             self.render_state.is_array_buffer_set = true;

--- a/src/render/shade.rs
+++ b/src/render/shade.rs
@@ -14,7 +14,7 @@
 
 //! Shader parameter handling.
 
-use std::cell::Cell;
+use std::cell::RefCell;
 use device::shade;
 use device::shade::UniformValue;
 use device::{handle, Resources};
@@ -120,7 +120,7 @@ pub struct NamedCell<T> {
     /// Name
     pub name: String,
     /// Value
-    pub value: Cell<T>,
+    pub value: RefCell<T>,
 }
 
 /// A dictionary of parameters, meant to be shared between different programs
@@ -166,13 +166,13 @@ impl<R: Resources> ShaderParam for ParamDictionary<R> {
 
     fn fill_params(&self, link: &ParamDictionaryLink, params: &mut ParamStorage<R>) {
         for &id in link.uniforms.iter() {
-            params.uniforms.push(self.uniforms[id].value.get());
+            params.uniforms.push(self.uniforms[id].value.borrow().clone());
         }
         for &id in link.blocks.iter() {
-            params.blocks.push(self.blocks[id].value.get());
+            params.blocks.push(self.blocks[id].value.borrow().clone());
         }
         for &id in link.textures.iter() {
-            params.textures.push(self.textures[id].value.get());
+            params.textures.push(self.textures[id].value.borrow().clone());
         }
     }
 }

--- a/src/render/shade.rs
+++ b/src/render/shade.rs
@@ -28,15 +28,15 @@ pub trait ToUniform {
     fn to_uniform(&self) -> shade::UniformValue;
 }
 
-macro_rules! impl_ToUniform(
-    ($ty_src:ty, $ty_dst:expr) => (
+macro_rules! impl_ToUniform{
+    ($ty_src:ty, $ty_dst:expr) => {
         impl ToUniform for $ty_src {
             fn to_uniform(&self) -> shade::UniformValue {
                 $ty_dst(*self)
             }
         }
-    );
-);
+    }
+}
 
 impl_ToUniform!(i32, UniformValue::I32);
 impl_ToUniform!(f32, UniformValue::F32);


### PR DESCRIPTION
Implements automatic management of the resources. Works just like RAII.

Closes #288, #617 

### User API changes:

- there is no such thing as  `factory.delete_something()` any more
- `Renderer` and `Factory` accept all handles by reference to avoid cloning
- `Factory` works with `RawBuffer` type natively now instead of `Buffer<()>`
- need to call `device.after_frame()` after `glfw.swap_buffers()`

### TODO:
- [X] infrastructure (`handle::Manager`)
- [X] Buffer and ArrayBuffer
- [X] Shader and Program
- [X] FrameBuffer and Surface
- [X] Texture and Sampler
- [X] update the device (https://github.com/gfx-rs/gfx_device_gl/pull/10)
- [X] cleanup resources at `after_free()`
- [X] update the macros (https://github.com/gfx-rs/gfx_macros/pull/5)
- [X] update the examples (https://github.com/gfx-rs/gfx_examples/pull/9)
- [X] verify resources to be deleted