### PR TITLE
Added index buffer flag

### DIFF
--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -340,7 +340,7 @@ impl<R: Resources> Manager<R> {
 mod test {
     use std::mem;
     use std::marker::PhantomData;
-    use device::{BufferInfo, BufferUsage, Resources};
+    use device::{BufferRole, BufferInfo, BufferUsage, Resources};
 
     #[derive(Clone, Debug, PartialEq)]
     enum TestResources {}
@@ -360,8 +360,9 @@ mod test {
         let mut handler = Manager::new();
         super::Buffer {
             raw: handler.make_buffer((), BufferInfo {
-                    usage: BufferUsage::Static,
-                    size: mem::size_of::<T>() * len,
+                role: BufferRole::Vertex,
+                usage: BufferUsage::Static,
+                size: mem::size_of::<T>() * len,
             }),
             phantom_t: PhantomData,
         }

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -31,7 +31,7 @@ pub struct Buffer<R: Resources, T> {
 }
 
 impl<R: Resources, T> Buffer<R, T> {
-    /// Create a type-safe BufferHandle from a RawBufferHandle
+    /// Create a type-safe Buffer from a RawBufferHandle
     pub fn from_raw(handle: RawBuffer<R>) -> Buffer<R, T> {
         Buffer {
             raw: handle,
@@ -42,6 +42,41 @@ impl<R: Resources, T> Buffer<R, T> {
     /// Cast the type this Buffer references
     pub fn cast<U>(self) -> Buffer<R, U> {
         Buffer::from_raw(self.raw)
+    }
+
+    /// Get the underlying raw Handle
+    pub fn raw(&self) -> &RawBuffer<R> {
+        &self.raw
+    }
+
+    /// Get the associated information about the buffer
+    pub fn get_info(&self) -> &BufferInfo {
+        self.raw.get_info()
+    }
+
+    /// Get the number of elements in the buffer.
+    ///
+    /// Fails if `T` is zero-sized.
+    pub fn len(&self) -> usize {
+        assert!(mem::size_of::<T>() != 0, "Cannot determine the length of zero-sized buffers.");
+        self.get_info().size / mem::size_of::<T>()
+    }
+}
+
+/// Type-safe index buffer handle
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct IndexBuffer<R: Resources, T> {
+    raw: RawBuffer<R>,
+    phantom_t: PhantomData<T>,
+}
+
+impl<R: Resources, T> IndexBuffer<R, T> {
+    /// Create a type-safe IndexBuffer from a RawBufferHandle
+    pub fn from_raw(handle: RawBuffer<R>) -> IndexBuffer<R, T> {
+        IndexBuffer {
+            raw: handle,
+            phantom_t: PhantomData,
+        }
     }
 
     /// Get the underlying raw Handle

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -169,14 +169,17 @@ pub trait Factory<R: Resources> {
     // resource creation
     fn create_buffer_raw(&mut self, size: usize, usage: BufferUsage) -> handle::RawBuffer<R>;
     fn create_buffer<T>(&mut self, num: usize, usage: BufferUsage) -> handle::Buffer<R, T> {
-        handle::Buffer::from_raw(self.create_buffer_raw(num * mem::size_of::<T>(), usage))
+        handle::Buffer::from_raw(
+            self.create_buffer_raw(num * mem::size_of::<T>(), usage))
     }
     fn create_buffer_static_raw(&mut self, data: &[u8], role: BufferRole) -> handle::RawBuffer<R>;
     fn create_buffer_static<T: Copy>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
-        handle::Buffer::from_raw(self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Vertex))
+        handle::Buffer::from_raw(
+            self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Vertex))
     }
-    fn create_buffer_index<T: Copy>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
-        handle::Buffer::from_raw(self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Index))
+    fn create_buffer_index<T: Copy>(&mut self, data: &[T]) -> handle::IndexBuffer<R, T> {
+        handle::IndexBuffer::from_raw(
+            self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Index))
     }
     fn create_array_buffer(&mut self) -> Result<handle::ArrayBuffer<R>, ()>;
     fn create_shader(&mut self, stage: shade::Stage, code: &[u8]) ->

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -111,6 +111,16 @@ pub enum PrimitiveType {
 /// A type of each index value in the mesh's index buffer
 pub type IndexType = attrib::IntSize;
 
+/// Role of the memory buffer. GLES doesn't chaning bind points for buffers.
+#[derive(Copy, Clone, Debug, Hash, PartialEq)]
+#[repr(u8)]
+pub enum BufferRole {
+    /// Generic vertex buffer
+    Vertex,
+    /// Index buffer
+    Index,
+}
+
 /// A hint as to how this buffer will be used.
 ///
 /// The nature of these hints make them very implementation specific. Different drivers on
@@ -131,6 +141,8 @@ pub enum BufferUsage {
 /// An information block that is immutable and associated with each buffer
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct BufferInfo {
+    /// Role
+    pub role: BufferRole,
     /// Usage hint
     pub usage: BufferUsage,
     /// Size in bytes
@@ -159,9 +171,12 @@ pub trait Factory<R: Resources> {
     fn create_buffer<T>(&mut self, num: usize, usage: BufferUsage) -> handle::Buffer<R, T> {
         handle::Buffer::from_raw(self.create_buffer_raw(num * mem::size_of::<T>(), usage))
     }
-    fn create_buffer_static_raw(&mut self, data: &[u8]) -> handle::RawBuffer<R>;
+    fn create_buffer_static_raw(&mut self, data: &[u8], role: BufferRole) -> handle::RawBuffer<R>;
     fn create_buffer_static<T: Copy>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
-        handle::Buffer::from_raw(self.create_buffer_static_raw(as_byte_slice(data)))
+        handle::Buffer::from_raw(self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Vertex))
+    }
+    fn create_buffer_index<T: Copy>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
+        handle::Buffer::from_raw(self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Index))
     }
     fn create_array_buffer(&mut self) -> Result<handle::ArrayBuffer<R>, ()>;
     fn create_shader(&mut self, stage: shade::Stage, code: &[u8]) ->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use render::ParamStorage;
 pub use device::{Device, Factory, Resources};
 pub use device::{attrib, tex};
 pub use device::as_byte_slice;
-pub use device::{BufferInfo, BufferUsage};
+pub use device::{BufferRole, BufferInfo, BufferUsage};
 pub use device::{VertexCount, InstanceCount};
 pub use device::PrimitiveType;
 pub use device::draw::CommandBuffer;

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -24,6 +24,7 @@ use device;
 use device::{PrimitiveType, Resources, VertexCount};
 use device::attrib;
 use device::handle::Buffer as BufferHandle;
+use device::handle::IndexBuffer as IndexBufferHandle;
 
 /// Describes a single attribute of a vertex buffer, including its type, name, etc.
 #[derive(Clone, Debug, Hash, PartialEq)]
@@ -127,11 +128,11 @@ pub enum SliceKind<R: Resources> {
     /// the vertices will be identical, wasting space for the duplicated
     /// attributes.  Instead, the `Mesh` can store 4 vertices and an
     /// `Index8` can be used instead.
-    Index8(BufferHandle<R, u8>, VertexCount),
+    Index8(IndexBufferHandle<R, u8>, VertexCount),
     /// As `Index8` but with `u16` indices
-    Index16(BufferHandle<R, u16>, VertexCount),
+    Index16(IndexBufferHandle<R, u16>, VertexCount),
     /// As `Index8` but with `u32` indices
-    Index32(BufferHandle<R, u32>, VertexCount),
+    Index32(IndexBufferHandle<R, u32>, VertexCount),
 }
 
 /// Helper methods for cleanly getting the slice of a type.
@@ -152,7 +153,7 @@ impl<R: Resources> ToSlice<R> for Mesh<R> {
     }
 }
 
-impl<R: Resources> ToSlice<R> for BufferHandle<R, u8> {
+impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u8> {
     /// Return an index slice of the whole buffer.
     fn to_slice(&self, ty: PrimitiveType) -> Slice<R> {
         Slice {
@@ -164,7 +165,7 @@ impl<R: Resources> ToSlice<R> for BufferHandle<R, u8> {
     }
 }
 
-impl<R: Resources> ToSlice<R> for BufferHandle<R, u16> {
+impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u16> {
     /// Return an index slice of the whole buffer.
     fn to_slice(&self, ty: PrimitiveType) -> Slice<R> {
         Slice {
@@ -176,7 +177,7 @@ impl<R: Resources> ToSlice<R> for BufferHandle<R, u16> {
     }
 }
 
-impl<R: Resources> ToSlice<R> for BufferHandle<R, u32> {
+impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u32> {
     /// Return an index slice of the whole buffer.
     fn to_slice(&self, ty: PrimitiveType) -> Slice<R> {
         Slice {

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -265,7 +265,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     /// Update a buffer with data from a single type.
     pub fn update_buffer_struct<U, T: Copy>(&mut self,
                                 buf: &handle::Buffer<R, U>, data: &T) {
-        debug_assert!(mem::size_of::<T>() <= buf.get_info().size);
+        assert!(mem::size_of::<T>() <= buf.get_info().size);
         let pointer = self.data_buffer.add_struct(data);
         self.command_buffer.update_buffer(
             self.handles.ref_buffer(buf.raw()), pointer, 0);
@@ -476,7 +476,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
         }
     }
 
-    fn bind_index<T>(&mut self, buf: &handle::Buffer<R, T>) {
+    fn bind_index<T>(&mut self, buf: &handle::IndexBuffer<R, T>) {
         if self.render_state.index.as_ref() != Some(buf.raw()) {
             self.render_state.index = Some(buf.raw().clone());
             self.command_buffer.bind_index(self.handles.ref_buffer(buf.raw()));


### PR DESCRIPTION
Fixes #643, requires more PRs in device and examples code.

### Use code changes:
- Use `create_buffer_index` for index buffer creation