### PR TITLE
Added SubmitInfo

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -218,6 +218,13 @@ pub trait Factory<R: Resources> {
     fn cleanup(&mut self);
 }
 
+/// All the data needed simultaneously for submitting a command buffer for
+/// execution on a device.
+pub type SubmitInfo<'a, D: Device> = (
+    &'a D::CommandBuffer,
+    &'a draw::DataBuffer,
+    &'a handle::Manager<D::Resources>
+);
 
 /// An interface for performing draw calls using a specific graphics API
 pub trait Device {
@@ -233,11 +240,7 @@ pub trait Device {
     fn reset_state(&mut self);
 
     /// Submit a command buffer for execution
-    fn submit(&mut self, (
-        &Self::CommandBuffer,
-        &draw::DataBuffer,
-        &handle::Manager<Self::Resources>
-    ));
+    fn submit(&mut self, SubmitInfo<Self>);
 
     /// Notify the finished frame
     fn after_frame(&mut self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ pub use render::mesh::{Slice, ToSlice, SliceKind};
 pub use render::shade;
 pub use render::target::{Frame, Plane};
 pub use render::ParamStorage;
-pub use device::{Device, Factory, Resources};
+pub use device::{Device, SubmitInfo, Factory, Resources};
 pub use device::{attrib, tex};
 pub use device::as_byte_slice;
 pub use device::{BufferRole, BufferInfo, BufferUsage};


### PR DESCRIPTION
Allows user applications to capture `Renderer::as_buffer` if needed.