### PR TITLE
Switched to use github version of draw_state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ authors = ["The Gfx-rs Developers"]
 name = "gfx"
 path = "src/lib.rs"
 
+[dependencies.draw_state]
+git = "https://github.com/gfx-rs/draw_state"
+version = "*"
+
 [dependencies]
 bitflags = "*"
 log = "*"
-
-[dependencies.draw_state]
-#git = "https://github.com/gfx-rs/draw_state"
-version = "*"


### PR DESCRIPTION
This is consistent with how we use `gfx-rs` from `gfx_device_gl` and other projects.