### PR TITLE
Factory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,3 +69,14 @@ pub use device::handle::Sampler as SamplerHandle;
 
 pub mod render;
 pub mod device;
+
+
+/// An abstract window that has the graphics context.
+pub trait Window {
+    /// Get width and height of the render area.
+    fn get_dimensions(&self) -> (u16, u16);
+    /// Get anti-aliasing mode.
+    fn get_aa_mode(&self) -> Option<device::tex::AaMode> { None }
+    /// Swap front and back buffers.
+    fn swap_buffers(&mut self);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate draw_state;
 pub mod traits {
     pub use device::{Device, Factory};
     pub use render::ext::device::DeviceExt;
-    pub use render::ext::factory::FactoryExt;
+    pub use render::ext::factory::{RenderFactory, FactoryExt};
     pub use render::mesh::ToSlice;
 }
 

--- a/src/render/ext/device.rs
+++ b/src/render/ext/device.rs
@@ -20,9 +20,15 @@ use device;
 use render::{batch, Renderer};
 use render::ext::factory::RenderFactory;
 use render::shade::ShaderParam;
+use render::target::Frame;
+
 
 /// A convenient wrapper suitable for single-threaded operation.
-pub struct Graphics<D: device::Device, F> {
+pub struct Graphics<W, D: device::Device, F> {
+    /// Owner window.
+    pub window: W,
+    /// Main frame buffer. Private to avoid modification.
+    main_frame: Frame<D::Resources>,
     /// Graphics device.
     pub device: D,
     /// Resource factory.
@@ -30,10 +36,10 @@ pub struct Graphics<D: device::Device, F> {
     /// Renderer front-end.
     pub renderer: Renderer<D::Resources, D::CommandBuffer>,
     /// Hidden batch context.
-    context: batch::Context<D::Resources>,
+    pub context: batch::Context<D::Resources>,
 }
 
-impl<D: device::Device, F> ops::Deref for Graphics<D, F> {
+impl<W, D: device::Device, F> ops::Deref for Graphics<W, D, F> {
     type Target = batch::Context<D::Resources>;
 
     fn deref(&self) -> &batch::Context<D::Resources> {
@@ -41,56 +47,67 @@ impl<D: device::Device, F> ops::Deref for Graphics<D, F> {
     }
 }
 
-impl<D: device::Device, F> ops::DerefMut for Graphics<D, F> {
+impl<W, D: device::Device, F> ops::DerefMut for Graphics<W, D, F> {
     fn deref_mut(&mut self) -> &mut batch::Context<D::Resources> {
         &mut self.context
     }
 }
 
 
-impl<D: device::Device, F: device::Factory<D::Resources>> Graphics<D, F> {
-    /// Clear the `Frame` as the `ClearData` specifies.
-    pub fn clear(&mut self, data: ::ClearData, mask: ::Mask, frame: &::Frame<D::Resources>) {
-        self.renderer.clear(data, mask, frame)
+impl<W: ::Window, D: device::Device, F: device::Factory<D::Resources>> Graphics<W, D, F> {
+    /// Clear the main frame with a given `ClearData`.
+    pub fn clear(&mut self, data: ::ClearData, mask: ::Mask) {
+        self.renderer.clear(data, mask, &self.main_frame)
     }
 
     /// Draw a `RefBatch` batch.
     pub fn draw<'a, T: ShaderParam<Resources = D::Resources>>(&'a mut self,
-                batch: &'a batch::RefBatch<T>, frame: &::Frame<D::Resources>)
+                batch: &'a batch::RefBatch<T>)
                 -> Result<(), ::DrawError<batch::OutOfBounds>> {
-        self.renderer.draw(&(batch, &self.context), frame)
+        self.renderer.draw(&(batch, &self.context), &self.main_frame)
     }
 
     /// Draw a `CoreBatch` batch.
     pub fn draw_core<'a, T: ShaderParam<Resources = D::Resources>>(&'a mut self,
                      core: &'a batch::CoreBatch<T>, slice: &'a ::Slice<D::Resources>,
-                     params: &'a T, frame: &::Frame<D::Resources>)
+                     params: &'a T)
                      -> Result<(), ::DrawError<batch::OutOfBounds>> {
-        self.renderer.draw(&self.context.bind(core, slice, params), frame)
+        self.renderer.draw(&self.context.bind(core, slice, params), &self.main_frame)
     }
 
     /// Submit the internal command buffer and reset for the next frame.
     pub fn end_frame(&mut self) {
+        // execute the commands
         self.device.submit(self.renderer.as_buffer());
+        // cleanup commands and resources
         self.renderer.reset();
-        // self.factory.after_frame();
+        self.device.after_frame();
+        self.factory.cleanup();
+        // update the frame dimension
+        let (w, h) = self.window.get_dimensions();
+        self.main_frame.width = w;
+        self.main_frame.height = h;
     }
 }
 
 
 /// Backend extension trait for convenience methods
-pub trait DeviceExt<D: device::Device, F> {
+pub trait DeviceExt<W, D: device::Device, F> {
     /// Convert to single-threaded wrapper
-    fn into_graphics(mut self) -> Graphics<D, F>;
+    fn into_graphics(mut self, window: W) -> Graphics<W, D, F>;
 }
 
 impl<
+    W: ::Window,
     D: device::Device,
     F: device::Factory<D::Resources>,
-> DeviceExt<D, F> for (D, F) {
-    fn into_graphics(mut self) -> Graphics<D, F> {
+> DeviceExt<W, D, F> for (D, F) {
+    fn into_graphics(mut self, window: W) -> Graphics<W, D, F> {
+        let (w, h) = window.get_dimensions();
         let rend = self.1.create_renderer();
         Graphics {
+            window: window,
+            main_frame: Frame::new(w, h),
             device: self.0,
             factory: self.1,
             renderer: rend,

--- a/src/render/ext/factory.rs
+++ b/src/render/ext/factory.rs
@@ -16,8 +16,35 @@
 
 use device;
 use device::shade::{Stage, CreateShaderError};
+use render::{Renderer, RenderState, ParamStorage};
 use render::mesh::{Mesh, VertexFormat};
 use super::shade::*;
+
+/// Factory extension that allows creating new renderers.
+pub trait RenderFactory<R: device::Resources, C: device::draw::CommandBuffer<R>> {
+    /// Create a new renderer
+    fn create_renderer(&mut self) -> Renderer<R, C>;
+}
+
+impl<
+    R: device::Resources,
+    C: device::draw::CommandBuffer<R>,
+    F: device::Factory<R>,
+> RenderFactory<R, C> for F {
+    fn create_renderer(&mut self) -> Renderer<R, C> {
+        Renderer {
+            command_buffer: device::draw::CommandBuffer::new(),
+            data_buffer: device::draw::DataBuffer::new(),
+            handles: device::handle::Manager::new(),
+            common_array_buffer: self.create_array_buffer(),
+            draw_frame_buffer: self.create_frame_buffer(),
+            read_frame_buffer: self.create_frame_buffer(),
+            default_frame_buffer: self.get_main_frame_buffer(),
+            render_state: RenderState::new(),
+            parameters: ParamStorage::new(),
+        }
+    }
+}
 
 /// Factory extension trait
 pub trait FactoryExt<R: device::Resources> {


### PR DESCRIPTION
First step towards #666 
This PR splits the `Factory` on the abstract gfx level. Another fix is needed on the device implementation side (https://github.com/gfx-rs/gfx_device_gl/pull/23). And I can't fix `gfx_examples` due to both `glfw-rs` and `glutin` being broken at this moment.

Please review carefully!

There is also an abstract window now, required for proper `Graphics` initialization. We'd need to implement it for `glutin`/`glfw`/`sdl` in separate crates (#529) in order to allow people to transition.

Use API changes:
  1. `into_graphics` is now called on the `(Device, Factory)` tuple.
  2. `Graphics` now explicitly contains `Factory`.
  3. `create_renderer` is implemented for the `Factory`.