### PR TITLE
adding set_info_kind function to TextureHandle

### DIFF
--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -149,11 +149,6 @@ pub struct Texture<R: Resources>(Arc<R::Texture>, tex::TextureInfo);
 impl<R: Resources> Texture<R> {
     /// Get texture info
     pub fn get_info(&self) -> &tex::TextureInfo { &self.1 }
-	/// Update texture info kind
-	pub fn set_info_kind(&mut self, kind: tex::TextureKind) {
-		// TODO mutable handles seems wrong.
-		self.1.kind = kind;
-	}
 }
 
 /// Sampler Handle

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -149,6 +149,11 @@ pub struct Texture<R: Resources>(Arc<R::Texture>, tex::TextureInfo);
 impl<R: Resources> Texture<R> {
     /// Get texture info
     pub fn get_info(&self) -> &tex::TextureInfo { &self.1 }
+	/// Update texture info kind
+	pub fn set_info_kind(&mut self, kind: tex::TextureKind) {
+		// TODO mutable handles seems wrong.
+		self.1.kind = kind;
+	}
 }
 
 /// Sampler Handle

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -206,11 +206,14 @@ pub trait Factory<R: Resources> {
     fn map_buffer_rw<T: Copy>(&mut self, &handle::Buffer<R, T>) -> mapping::RW<T, R, Self>;
 
     /// Update the information stored in a texture
-    fn update_texture_raw(&mut self, tex: &handle::Texture<R>, img: &tex::ImageInfo, data: &[u8])
-                          -> Result<(), tex::TextureError>;
-    fn update_texture<T: Copy>(&mut self, tex: &handle::Texture<R>, img: &tex::ImageInfo, data: &[T])
-                      -> Result<(), tex::TextureError> {
-        self.update_texture_raw(tex, img, as_byte_slice(data))
+    fn update_texture_raw(&mut self, tex: &handle::Texture<R>,
+					img: &tex::ImageInfo, data: &[u8],
+					kind: Option<&tex::TextureKind>) -> Result<(), tex::TextureError>;
+
+    fn update_texture<T: Copy>(&mut self, tex: &handle::Texture<R>, 
+					img: &tex::ImageInfo, data: &[T],
+					kind: Option<&tex::TextureKind>) -> Result<(), tex::TextureError> {
+        self.update_texture_raw(tex, img, as_byte_slice(data), kind)
     }
     fn generate_mipmap(&mut self, &handle::Texture<R>);
 


### PR DESCRIPTION
Intended for use with the `TextureCube` TextureKind, when populating all 6 sub-textures for example:
```
		for side in [CubeFace::PosY, CubeFace::NegY, CubeFace::NegX,
					 CubeFace::NegZ, CubeFace::PosX, CubeFace::PosZ].iter() {

			let env_data = cubemap_file.read_exact(env_resolution * env_resolution * 3).unwrap();

			env_tex.set_info_kind(gfx::tex::TextureKind::TextureCube(*side));

			self.rs.device.update_texture(&env_tex, &env_ii, &env_data);
		}
```