### PR TITLE
Fix compilation with fresh build of rustc.

### DIFF
--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -22,7 +22,7 @@ type Offset = u32;
 type Size = u32;
 
 /// The place of some data in the data buffer.
-#[derive(Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub struct DataPointer(Offset, Size);
 
 /// A buffer of data accompanying the commands. It can be vertex data, texture

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -51,7 +51,7 @@ pub fn as_byte_slice<T>(slice: &[T]) -> &[u8] {
 }
 
 /// Features that the device supports.
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[allow(missing_docs)] // pretty self-explanatory fields!
 pub struct Capabilities {
     pub shader_model: shade::ShaderModel,
@@ -73,7 +73,7 @@ pub struct Capabilities {
 }
 
 /// Specifies the access allowed to a buffer mapping.
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub enum MapAccess {
     /// Only allow reads.
     Readable,

--- a/src/device/shade.rs
+++ b/src/device/shade.rs
@@ -276,7 +276,7 @@ pub struct ProgramInfo {
 }
 
 /// Error type for trying to store a UniformValue in a UniformVar.
-#[derive(Copy, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum CompatibilityError {
     /// Array sizes differ between the value and the var (trying to upload a vec2 as a vec4, etc)
     ErrorArraySize,

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -329,7 +329,7 @@ impl Default for TextureInfo {
             width: 0,
             height: 1,
             depth: 1,
-            levels: -1,
+            levels: u8::max_value(),
             kind: TextureKind::Texture2D,
             format: RGBA8,
         }

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -160,9 +160,10 @@ impl<T: ShaderParam> Batch for OwnedBatch<T> {
 type Index = u16;
 
 //#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone)]
 struct Id<T>(Index, PhantomData<T>);
 
-impl<T> Copy for Id<T> {}
+impl<T: Clone> Copy for Id<T> {}
 
 impl<T> Id<T> {
     fn unwrap(&self) -> Index {
@@ -244,6 +245,7 @@ impl<T: Clone + PartialEq> Array<T> {
 /// Referenced core - a minimal sealed batch that depends on `Context`.
 /// It has references to the resources (mesh, program, state), that are held
 /// by the context that created the batch, so these have to be used together.
+#[derive(Clone)]
 pub struct CoreBatch<T: ShaderParam> {
     mesh_id: Id<mesh::Mesh<T::Resources>>,
     mesh_link: mesh::Link,
@@ -252,7 +254,7 @@ pub struct CoreBatch<T: ShaderParam> {
     state_id: Id<DrawState>,
 }
 
-impl<T: ShaderParam> Copy for CoreBatch<T> where T::Link: Copy {}
+impl<T: ShaderParam + Clone> Copy for CoreBatch<T> where T::Link: Copy {}
 
 impl<T: ShaderParam> fmt::Debug for CoreBatch<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -211,7 +211,7 @@ const MESH_ATTRIBUTE_MASK: AttributeIndex = (1 << BITS_PER_ATTRIBUTE) - 1;
 const MAX_SHADER_INPUTS: usize = 64 / BITS_PER_ATTRIBUTE;
 
 /// An iterator over mesh attributes.
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct AttributeIter {
     value: u64,
 }
@@ -227,7 +227,7 @@ impl Iterator for AttributeIter {
 }
 
 /// Holds a remapping table from shader inputs to mesh attributes.
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct Link {
     table: u64,
 }


### PR DESCRIPTION
Fixes compilation errors on rustc 1.0.0-nightly (d17d6e7f1 2015-04-02) (built 2015-04-03).

* Copy trait requires Clone to be implemented or derived.
* -1 as a u8 value seems to be deprecated, can be replaced with a call on a type.