### PR TITLE
Canvas - take 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.2.6"
+version = "0.2.7"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate draw_state;
 /// public re-exported traits
 pub mod traits {
     pub use device::{Device, Factory};
+    pub use render::ext::canvas::IntoCanvas;
     pub use render::ext::device::DeviceExt;
     pub use render::ext::factory::{RenderFactory, FactoryExt};
     pub use render::mesh::ToSlice;
@@ -39,6 +40,7 @@ pub use draw_state::{DrawState, BlendPreset};
 // public re-exports
 pub use render::{Renderer, DrawError};
 pub use render::batch;
+pub use render::ext::canvas::{Canvas, Window};
 pub use render::ext::device::Graphics;
 pub use render::ext::shade::{ShaderSource, ProgramError};
 pub use render::mesh::{Attribute, Mesh, VertexFormat};

--- a/src/render/ext/canvas.rs
+++ b/src/render/ext/canvas.rs
@@ -1,0 +1,55 @@
+// Copyright 2015 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use device::{Device, Factory, Resources};
+use render::target::Output;
+use render::Renderer;
+
+
+/// Generic output window.
+pub trait Window<R: Resources>: Output<R> {
+    /// Swap front and back buffers.
+    fn swap_buffers(&mut self);
+}
+
+/// A canvas with everything you need to draw on it.
+pub struct Canvas<W, D: Device, F> {
+    /// Output window.
+    pub output: W,
+    /// Graphics device.
+    pub device: D,
+    /// Resource factory.
+    pub factory: F,
+    /// Renderer front-end.
+    pub renderer: Renderer<D::Resources, D::CommandBuffer>,
+}
+
+/// Something that can be transformed into `Canvas`.
+pub trait IntoCanvas<W, D: Device, F> {
+    /// Transform into `Canvas`.
+    fn into_canvas(self) -> Canvas<W, D, F>;
+}
+
+impl<W, D: Device, F: Factory<D::Resources>> IntoCanvas<W, D, F> for (W, D, F) {
+    fn into_canvas(mut self) -> Canvas<W, D, F> {
+        use super::factory::RenderFactory;
+        let renderer = self.2.create_renderer();
+        Canvas {
+            output: self.0,
+            device: self.1,
+            factory: self.2,
+            renderer: renderer,
+        }
+    }
+}

--- a/src/render/ext/mod.rs
+++ b/src/render/ext/mod.rs
@@ -16,6 +16,8 @@
 
 #![deny(missing_docs)]
 
+/// Canvas
+pub mod canvas;
 /// Device extensions
 pub mod device;
 /// Factory extensions


### PR DESCRIPTION
Closes #529
Closes #678 
Window Glutin: https://github.com/gfx-rs/gfx_window_glutin/pull/4
Window GLFW: https://github.com/gfx-rs/gfx_window_glfw/pull/2
Examples: https://github.com/gfx-rs/gfx_examples/pull/16

Canvas is a convenient wrapper around a window, device, factory, and a renderer. It allows you to draw stuff with sufficiently less parameters, while still treating `Batch` generically (unlike `Graphics`). It is meant to work with `gfx_window_*` crates for minimal boilerplate initialization. The `present` method will take care of the buffer swapping, renderer reset, and resource cleanups, thus leaving no chance to miss anything.