### PR TITLE
Improved texture creation helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.2.7"
+version = "0.2.8"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -212,7 +212,19 @@ pub trait Factory<R: Resources> {
                           kind: Option<tex::TextureKind>) -> Result<(), tex::TextureError> {
         self.update_texture_raw(tex, img, as_byte_slice(data), kind)
     }
+
     fn generate_mipmap(&mut self, &handle::Texture<R>);
+
+    /// Create a new texture with given data
+    fn create_texture_static<T: Copy>(&mut self, info: tex::TextureInfo, data: &[T])
+                             -> Result<handle::Texture<R>, tex::TextureError> {
+        let image_info = info.to_image_info();
+        match self.create_texture(info) {
+            Ok(handle) => self.update_texture(&handle, &image_info, data, None)
+                              .map(|_| handle),
+            Err(e) => Err(e),
+        }
+    }
 
     /// Clean up all unreferenced resources
     fn cleanup(&mut self);


### PR DESCRIPTION
Also, fixing this error with the previous helper:
> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Texture(Invalid data size provided to update the texture, expected size 0)', /home/rustbuild/src/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/libcore/result.rs:750
