### PR TITLE
[don't merge] Unstable feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
 - nightly
-#- beta
+- 1.0.0-beta.4
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.3.0"
+version = "0.3.1"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -52,6 +52,7 @@ impl DataBuffer {
         self.add_vec(ref_slice(v))
     }
 
+    /// Copy a given structure into the buffer, return the offset and the size.
     #[cfg(not(unstable))]
     pub fn add_struct<T: Copy>(&mut self, v: &T) -> DataPointer {
         use std::{intrinsics, mem};

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -45,23 +45,39 @@ impl DataBuffer {
     }
 
     /// Copy a given structure into the buffer, return the offset and the size.
+    #[cfg(unstable)]
     #[inline(always)]
     pub fn add_struct<T: Copy>(&mut self, v: &T) -> DataPointer {
         use std::slice::ref_slice;
         self.add_vec(ref_slice(v))
     }
 
+    #[cfg(not(unstable))]
+    pub fn add_struct<T: Copy>(&mut self, v: &T) -> DataPointer {
+        use std::{intrinsics, mem};
+        let offset = self.buf.len();
+        let size = mem::size_of::<T>();
+        self.buf.reserve(size);
+        unsafe {
+            self.buf.set_len(offset + size);
+            intrinsics::copy((v as *const T) as *const u8,
+                             &mut self.buf[offset] as *mut u8,
+                             size);
+        };
+        DataPointer(offset as Offset, size as Size)
+    }
+
     /// Copy a given vector slice into the buffer
     pub fn add_vec<T: Copy>(&mut self, v: &[T]) -> DataPointer {
-        use std::{mem, slice};
+        use std::{intrinsics, mem};
         let offset = self.buf.len();
         let size = mem::size_of::<T>() * v.len();
         self.buf.reserve(size);
         unsafe {
             self.buf.set_len(offset + size);
-            slice::bytes::copy_memory(
-                slice::from_raw_parts(v.as_ptr() as *const u8, size),
-                &mut self.buf[offset ..]);
+            intrinsics::copy(v.as_ptr() as *const u8,
+                             &mut self.buf[offset] as *mut u8,
+                             size);
         }
         DataPointer(offset as Offset, size as Size)
     }

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -30,7 +30,7 @@ pub struct Buffer<R: Resources, T> {
 }
 
 impl<R: Resources, T> Buffer<R, T> {
-    /// Create a type-safe Buffer from a RawBufferHandle
+    /// Create a type-safe Buffer from a RawBuffer
     pub fn from_raw(handle: RawBuffer<R>) -> Buffer<R, T> {
         Buffer {
             raw: handle,
@@ -70,7 +70,7 @@ pub struct IndexBuffer<R: Resources, T> {
 }
 
 impl<R: Resources, T> IndexBuffer<R, T> {
-    /// Create a type-safe IndexBuffer from a RawBufferHandle
+    /// Create a type-safe IndexBuffer from a RawBuffer
     pub fn from_raw(handle: RawBuffer<R>) -> IndexBuffer<R, T> {
         IndexBuffer {
             raw: handle,

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -16,7 +16,7 @@
 
 //! Graphics device. Not meant for direct use.
 
-use std::{fmt, mem, raw};
+use std::{fmt, mem};
 use std::hash::Hash;
 
 pub use draw_state::target;
@@ -44,9 +44,11 @@ pub type TextureSlot = u8;
 
 /// Treat a given slice as `&[u8]` for the given function call
 pub fn as_byte_slice<T>(slice: &[T]) -> &[u8] {
+    use std::slice;
     let len = mem::size_of::<T>() * slice.len();
-    let slice = raw::Slice { data: slice.as_ptr(), len: len };
-    unsafe { mem::transmute(slice) }
+    unsafe {
+        slice::from_raw_parts(slice.as_ptr() as *const u8, len)
+    }
 }
 
 /// Features that the device supports.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@
 //! An efficient, low-level, bindless graphics API for Rust. See [the
 //! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
 
-#![feature(alloc, core)]
-
-extern crate alloc;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/render/target.rs
+++ b/src/render/target.rs
@@ -89,10 +89,20 @@ impl<R: Resources> Output<R> for Plane<R> {
         (info.width, info.height)
     }
 
+    #[cfg(unstable)]
     fn get_colors(&self) -> &[Plane<R>] {
         use std::slice::ref_slice;
         if self.get_format().is_color() {
             ref_slice(self)
+        }else {
+            &[]
+        }
+    }
+
+    #[cfg(not(unstable))]
+    fn get_colors(&self) -> &[Plane<R>] {
+        if self.get_format().is_color() {
+            unimplemented!()
         }else {
             &[]
         }


### PR DESCRIPTION
Replaces `rust-1.0` branch.
Closes #716 

Current problems:
  - resource cleanup doesn't work
  - macros are not ported