### PR TITLE
This adds a custom Arc type for stable reason

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
 - nightly
-#- beta
+- 1.0.0-beta.4
 before_script:
 - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 notifications:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.3.0"
+version = "0.3.1"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/device/arc.rs
+++ b/src/device/arc.rs
@@ -1,0 +1,149 @@
+// Copyright 2014 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//*****************************************************************************
+// THIS IS A HUGE HACK AND WE WANT TO USE std::sync::Arc
+// this will be removed once `is_unqiue` or something similar is stabilized.
+//*****************************************************************************
+
+
+use std::sync::atomic::*;
+use std::ops::Deref;
+use std::mem;
+use std::fmt;
+use std::hash;
+
+struct Inner<T> {
+    refs: AtomicUsize,
+    data: T
+}
+
+pub struct Arc<T>(*const Inner<T>);
+
+unsafe impl<T:Send+Sync> Send for Arc<T> {}
+unsafe impl<T:Send+Sync> Sync for Arc<T> {}
+
+impl<T:Send+Sync> Arc<T> {
+    /// Create a new Arc<T>
+    pub fn new(data: T) -> Arc<T> {
+        let inner = Box::new(Inner {
+            refs: AtomicUsize::new(1),
+            data: data
+        });
+
+        unsafe {
+            Arc(mem::transmute(inner))
+        }
+    }
+}
+
+impl<T> Arc<T> {
+    /// Check to see if this is unique
+    pub fn is_unique(&mut self) -> Option<&T> {
+        unsafe {
+            if 1 == (*self.0).refs.load(Ordering::SeqCst) {
+                Some(&(*self.0).data)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+impl<T> Clone for Arc<T> {
+    fn clone(&self) -> Arc<T> {
+        unsafe {
+            (*self.0).refs.fetch_add(1, Ordering::SeqCst);
+        }
+        Arc(self.0)
+    }
+}
+
+impl<T> Deref for Arc<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe {
+            &(*self.0).data
+        }
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Arc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        self.deref().fmt(f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for Arc<T> {
+    fn eq(&self, other: &Arc<T>) -> bool {
+        self.deref() == other.deref()
+    }
+}
+
+impl<T: Eq> Eq for Arc<T> {}
+
+impl<T: hash::Hash> hash::Hash for Arc<T> {
+    fn hash<H>(&self, state: &mut H) where H: hash::Hasher {
+        self.deref().hash(state)
+    }
+}
+
+impl<T> Drop for Arc<T> {
+    fn drop(&mut self) {
+        unsafe {
+            if 1 == (*self.0).refs.fetch_sub(1, Ordering::SeqCst) {
+                let _: Box<Inner<T>> = mem::transmute(self.0);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Arc;
+    use std::sync::Arc as StdArc;
+    use std::sync::atomic::*;
+
+    struct Canary(StdArc<AtomicUsize>);
+
+    impl Drop for Canary {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn testing_drop() {
+        let inner = StdArc::new(AtomicUsize::new(0));
+        let data = Arc::new(Canary(inner.clone()));
+
+        assert_eq!(0, inner.load(Ordering::SeqCst));
+        drop(data.clone());
+        assert_eq!(0, inner.load(Ordering::SeqCst));
+        drop(data);
+        assert_eq!(1, inner.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn testing_unique() {
+        let mut data = Arc::new(0);
+        assert!(data.is_unique().is_some());
+        let mut data2 = data.clone();
+        assert!(data.is_unique().is_none());
+        assert!(data2.is_unique().is_none());
+        drop(data);
+        assert!(data2.is_unique().is_some());
+    }
+}

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -52,6 +52,7 @@ impl DataBuffer {
         self.add_vec(ref_slice(v))
     }
 
+    /// Copy a given structure into the buffer, return the offset and the size.
     #[cfg(not(unstable))]
     pub fn add_struct<T: Copy>(&mut self, v: &T) -> DataPointer {
         use std::{intrinsics, mem};

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -45,23 +45,39 @@ impl DataBuffer {
     }
 
     /// Copy a given structure into the buffer, return the offset and the size.
+    #[cfg(unstable)]
     #[inline(always)]
     pub fn add_struct<T: Copy>(&mut self, v: &T) -> DataPointer {
         use std::slice::ref_slice;
         self.add_vec(ref_slice(v))
     }
 
+    #[cfg(not(unstable))]
+    pub fn add_struct<T: Copy>(&mut self, v: &T) -> DataPointer {
+        use std::{intrinsics, mem};
+        let offset = self.buf.len();
+        let size = mem::size_of::<T>();
+        self.buf.reserve(size);
+        unsafe {
+            self.buf.set_len(offset + size);
+            intrinsics::copy((v as *const T) as *const u8,
+                             &mut self.buf[offset] as *mut u8,
+                             size);
+        };
+        DataPointer(offset as Offset, size as Size)
+    }
+
     /// Copy a given vector slice into the buffer
     pub fn add_vec<T: Copy>(&mut self, v: &[T]) -> DataPointer {
-        use std::{mem, slice};
+        use std::{intrinsics, mem};
         let offset = self.buf.len();
         let size = mem::size_of::<T>() * v.len();
         self.buf.reserve(size);
         unsafe {
             self.buf.set_len(offset + size);
-            slice::bytes::copy_memory(
-                slice::from_raw_parts(v.as_ptr() as *const u8, size),
-                &mut self.buf[offset ..]);
+            intrinsics::copy(v.as_ptr() as *const u8,
+                             &mut self.buf[offset] as *mut u8,
+                             size);
         }
         DataPointer(offset as Offset, size as Size)
     }

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -30,7 +30,7 @@ pub struct Buffer<R: Resources, T> {
 }
 
 impl<R: Resources, T> Buffer<R, T> {
-    /// Create a type-safe Buffer from a RawBufferHandle
+    /// Create a type-safe Buffer from a RawBuffer
     pub fn from_raw(handle: RawBuffer<R>) -> Buffer<R, T> {
         Buffer {
             raw: handle,
@@ -70,7 +70,7 @@ pub struct IndexBuffer<R: Resources, T> {
 }
 
 impl<R: Resources, T> IndexBuffer<R, T> {
-    /// Create a type-safe IndexBuffer from a RawBufferHandle
+    /// Create a type-safe IndexBuffer from a RawBuffer
     pub fn from_raw(handle: RawBuffer<R>) -> IndexBuffer<R, T> {
         IndexBuffer {
             raw: handle,

--- a/src/device/handle.rs
+++ b/src/device/handle.rs
@@ -19,7 +19,7 @@
 use std::mem;
 use std::marker::PhantomData;
 use std::ops::Deref;
-use std::sync::Arc;
+use super::arc::Arc;
 use super::{shade, tex, Resources, BufferInfo};
 
 /// Type-safe buffer handle
@@ -261,11 +261,10 @@ impl<R: Resources> Producer<R> for Manager<R> {
         F8: Fn(&mut T, &R::Sampler),
     >(&mut self, param: &mut T, f1: F1, f2: F2, f3: F3, f4: F4, f5: F5, f6: F6, f7: F7, f8: F8) {
         fn clean_vec<X: Clone, T, F: Fn(&mut T, &X)>(param: &mut T, vector: &mut Vec<Arc<X>>, fun: F) {
-            fn is_unique<T>(_: &mut Arc<T>) -> Option<&T> { None }
             let mut temp = Vec::new();
             // delete unique resources and make a list of their indices
             for (i, v) in vector.iter_mut().enumerate() {
-                if let Some(r) = is_unique(v) {
+                if let Some(r) = v.is_unique() {
                     fun(param, r);
                     temp.push(i);
                 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -28,6 +28,7 @@ pub mod handle;
 pub mod mapping;
 pub mod shade;
 pub mod tex;
+mod arc;
 
 /// Draw vertex count.
 pub type VertexCount = u32;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -16,7 +16,7 @@
 
 //! Graphics device. Not meant for direct use.
 
-use std::{fmt, mem, raw};
+use std::{fmt, mem};
 use std::hash::Hash;
 
 pub use draw_state::target;
@@ -44,9 +44,11 @@ pub type TextureSlot = u8;
 
 /// Treat a given slice as `&[u8]` for the given function call
 pub fn as_byte_slice<T>(slice: &[T]) -> &[u8] {
+    use std::slice;
     let len = mem::size_of::<T>() * slice.len();
-    let slice = raw::Slice { data: slice.as_ptr(), len: len };
-    unsafe { mem::transmute(slice) }
+    unsafe {
+        slice::from_raw_parts(slice.as_ptr() as *const u8, len)
+    }
 }
 
 /// Features that the device supports.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@
 //! An efficient, low-level, bindless graphics API for Rust. See [the
 //! blog](http://gfx-rs.github.io/) for explanations and annotated examples.
 
-#![feature(alloc, core)]
-
-extern crate alloc;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/src/render/target.rs
+++ b/src/render/target.rs
@@ -89,10 +89,20 @@ impl<R: Resources> Output<R> for Plane<R> {
         (info.width, info.height)
     }
 
+    #[cfg(unstable)]
     fn get_colors(&self) -> &[Plane<R>] {
         use std::slice::ref_slice;
         if self.get_format().is_color() {
             ref_slice(self)
+        }else {
+            &[]
+        }
+    }
+
+    #[cfg(not(unstable))]
+    fn get_colors(&self) -> &[Plane<R>] {
+        if self.get_format().is_color() {
+            unimplemented!()
         }else {
             &[]
         }


### PR DESCRIPTION
This includes: https://github.com/gfx-rs/gfx-rs/pull/719 (Feel free to cherry-pick this change if you want to include it what that changeset).

This creates a custom Arc type so that we can use `is_unique` in our codebase.

This could be a breaking change as I do not have the full `Arc` for example `Display` is missing.