### PR TITLE
Macros return!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.3.1"
+version = "0.4.0"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/device/attrib.rs
+++ b/src/device/attrib.rs
@@ -125,9 +125,50 @@ pub struct Format {
     pub instance_rate: InstanceRate,
 }
 
+
+/// Fixed-point version of integer attributes.
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+pub struct FixedPoint<T>(pub T);
+
+impl<T: Copy> FixedPoint<T> {
+    /// Cast a fixed-size2 array to fixed-point.
+    pub fn cast2(a: [T; 2]) -> [FixedPoint<T>; 2] {
+        [FixedPoint(a[0]), FixedPoint(a[1])]
+    }
+    /// Cast a fixed-size3 array to fixed-point.
+    pub fn cast3(a: [T; 3]) -> [FixedPoint<T>; 3] {
+        [FixedPoint(a[0]), FixedPoint(a[1]), FixedPoint(a[2])]
+    }
+    /// Cast a fixed-size4 array to fixed-point.
+    pub fn cast4(a: [T; 4]) -> [FixedPoint<T>; 4] {
+        [FixedPoint(a[0]), FixedPoint(a[1]),
+         FixedPoint(a[2]), FixedPoint(a[3])]
+    }
+}
+
+/// Floating-point version of integer attributes.
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+pub struct Floater<T>(pub T);
+
+impl<T: Copy> Floater<T> {
+    /// Cast a fixed-size2 array to floating-point.
+    pub fn cast2(a: [T; 2]) -> [Floater<T>; 2] {
+        [Floater(a[0]), Floater(a[1])]
+    }
+    /// Cast a fixed-size3 array to floating-point.
+    pub fn cast3(a: [T; 3]) -> [Floater<T>; 3] {
+        [Floater(a[0]), Floater(a[1]), Floater(a[2])]
+    }
+    /// Cast a fixed-size4 array to floating-point.
+    pub fn cast4(a: [T; 4]) -> [Floater<T>; 4] {
+        [Floater(a[0]), Floater(a[1]),
+         Floater(a[2]), Floater(a[3])]
+    }
+}
+
 /// A service module for deriving `ToFormat` for primitive types.
 pub mod format {
-    use super::{Count, Type};
+    use super::{Count, FixedPoint, Floater, Type};
     use super::Type::*;
     use super::FloatSize::*;
     use super::FloatSubType::*;
@@ -192,25 +233,41 @@ pub mod format {
         fn describe() -> Type { Int(Raw, U32, Signed) }
     }
 
-    /// Fixed-point version of integer attributes.
-    pub struct FixedPoint<T>(pub T);
-
     impl ToType for FixedPoint<u8> {
-        fn describe() -> Type { Int(Raw, U8, Unsigned) }
+        fn describe() -> Type { Int(Normalized, U8, Unsigned) }
     }
     impl ToType for FixedPoint<u16> {
-        fn describe() -> Type { Int(Raw, U16, Unsigned) }
+        fn describe() -> Type { Int(Normalized, U16, Unsigned) }
     }
     impl ToType for FixedPoint<u32> {
-        fn describe() -> Type { Int(Raw, U32, Unsigned) }
+        fn describe() -> Type { Int(Normalized, U32, Unsigned) }
     }
     impl ToType for FixedPoint<i8> {
-        fn describe() -> Type { Int(Raw, U8, Signed) }
+        fn describe() -> Type { Int(Normalized, U8, Signed) }
     }
     impl ToType for FixedPoint<i16> {
-        fn describe() -> Type { Int(Raw, U16, Signed) }
+        fn describe() -> Type { Int(Normalized, U16, Signed) }
     }
     impl ToType for FixedPoint<i32> {
-        fn describe() -> Type { Int(Raw, U32, Signed) }
+        fn describe() -> Type { Int(Normalized, U32, Signed) }
+    }
+
+    impl ToType for Floater<u8> {
+        fn describe() -> Type { Int(AsFloat, U8, Unsigned) }
+    }
+    impl ToType for Floater<u16> {
+        fn describe() -> Type { Int(AsFloat, U16, Unsigned) }
+    }
+    impl ToType for Floater<u32> {
+        fn describe() -> Type { Int(AsFloat, U32, Unsigned) }
+    }
+    impl ToType for Floater<i8> {
+        fn describe() -> Type { Int(AsFloat, U8, Signed) }
+    }
+    impl ToType for Floater<i16> {
+        fn describe() -> Type { Int(AsFloat, U16, Signed) }
+    }
+    impl ToType for Floater<i32> {
+        fn describe() -> Type { Int(AsFloat, U32, Signed) }
     }
 }

--- a/src/device/attrib.rs
+++ b/src/device/attrib.rs
@@ -124,3 +124,93 @@ pub struct Format {
     /// Instance rate per vertex
     pub instance_rate: InstanceRate,
 }
+
+/// A service module for deriving `ToFormat` for primitive types.
+pub mod format {
+    use super::{Count, Type};
+    use super::Type::*;
+    use super::FloatSize::*;
+    use super::FloatSubType::*;
+    use super::IntSize::*;
+    use super::IntSubType::*;
+    use super::SignFlag::*;
+
+    /// A trait for getting the format out of vertex element types.
+    /// Needed to implement `VertexFormat` with a macro.
+    pub trait ToFormat {
+        fn describe() -> (Count, Type);
+    }
+
+    /// A helper trait for implementing ToFormat.
+    pub trait ToType {
+        fn describe() -> Type;
+    }
+
+    impl<T: ToType> ToFormat for T {
+        fn describe() -> (Count, Type) {
+            (1, T::describe())
+        }
+    }
+    impl<T: ToType> ToFormat for [T; 2] {
+        fn describe() -> (Count, Type) {
+            (2, T::describe())
+        }
+    }
+    impl<T: ToType> ToFormat for [T; 3] {
+        fn describe() -> (Count, Type) {
+            (3, T::describe())
+        }
+    }
+    impl<T: ToType> ToFormat for [T; 4] {
+        fn describe() -> (Count, Type) {
+            (4, T::describe())
+        }
+    }
+
+    impl ToType for f32 {
+        fn describe() -> Type { Float(Default, F32) }
+    }
+    impl ToType for f64 {
+        fn describe() -> Type { Float(Precision, F64) }
+    }
+    impl ToType for u8 {
+        fn describe() -> Type { Int(Raw, U8, Unsigned) }
+    }
+    impl ToType for u16 {
+        fn describe() -> Type { Int(Raw, U16, Unsigned) }
+    }
+    impl ToType for u32 {
+        fn describe() -> Type { Int(Raw, U32, Unsigned) }
+    }
+    impl ToType for i8 {
+        fn describe() -> Type { Int(Raw, U8, Signed) }
+    }
+    impl ToType for i16 {
+        fn describe() -> Type { Int(Raw, U16, Signed) }
+    }
+    impl ToType for i32 {
+        fn describe() -> Type { Int(Raw, U32, Signed) }
+    }
+
+    /// Fixed-point version of integer attributes.
+    pub struct FixedPoint<T>(pub T);
+
+    impl ToType for FixedPoint<u8> {
+        fn describe() -> Type { Int(Raw, U8, Unsigned) }
+    }
+    impl ToType for FixedPoint<u16> {
+        fn describe() -> Type { Int(Raw, U16, Unsigned) }
+    }
+    impl ToType for FixedPoint<u32> {
+        fn describe() -> Type { Int(Raw, U32, Unsigned) }
+    }
+    impl ToType for FixedPoint<i8> {
+        fn describe() -> Type { Int(Raw, U8, Signed) }
+    }
+    impl ToType for FixedPoint<i16> {
+        fn describe() -> Type { Int(Raw, U16, Signed) }
+    }
+    impl ToType for FixedPoint<i32> {
+        fn describe() -> Type { Int(Raw, U32, Signed) }
+    }
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -176,11 +176,11 @@ pub trait Factory<R: Resources> {
             self.create_buffer_raw(num * mem::size_of::<T>(), usage))
     }
     fn create_buffer_static_raw(&mut self, data: &[u8], role: BufferRole) -> handle::RawBuffer<R>;
-    fn create_buffer_static<T: Copy>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
+    fn create_buffer_static<T>(&mut self, data: &[T]) -> handle::Buffer<R, T> {
         handle::Buffer::from_raw(
             self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Vertex))
     }
-    fn create_buffer_index<T: Copy>(&mut self, data: &[T]) -> handle::IndexBuffer<R, T> {
+    fn create_buffer_index<T>(&mut self, data: &[T]) -> handle::IndexBuffer<R, T> {
         handle::IndexBuffer::from_raw(
             self.create_buffer_static_raw(as_byte_slice(data), BufferRole::Index))
     }
@@ -196,7 +196,7 @@ pub trait Factory<R: Resources> {
 
     /// Update the information stored in a specific buffer
     fn update_buffer_raw(&mut self, buf: &handle::RawBuffer<R>, data: &[u8], offset_bytes: usize);
-    fn update_buffer<T: Copy>(&mut self, buf: &handle::Buffer<R, T>, data: &[T], offset_elements: usize) {
+    fn update_buffer<T>(&mut self, buf: &handle::Buffer<R, T>, data: &[T], offset_elements: usize) {
         self.update_buffer_raw(buf.raw(), as_byte_slice(data), mem::size_of::<T>() * offset_elements)
     }
     fn map_buffer_raw(&mut self, &handle::RawBuffer<R>, MapAccess) -> Self::Mapper;
@@ -210,16 +210,16 @@ pub trait Factory<R: Resources> {
                           img: &tex::ImageInfo, data: &[u8],
                           kind: Option<tex::TextureKind>) -> Result<(), tex::TextureError>;
 
-    fn update_texture<T: Copy>(&mut self, tex: &handle::Texture<R>, 
-                          img: &tex::ImageInfo, data: &[T],
-                          kind: Option<tex::TextureKind>) -> Result<(), tex::TextureError> {
+    fn update_texture<T>(&mut self, tex: &handle::Texture<R>,
+                         img: &tex::ImageInfo, data: &[T],
+                         kind: Option<tex::TextureKind>) -> Result<(), tex::TextureError> {
         self.update_texture_raw(tex, img, as_byte_slice(data), kind)
     }
 
     fn generate_mipmap(&mut self, &handle::Texture<R>);
 
     /// Create a new texture with given data
-    fn create_texture_static<T: Copy>(&mut self, info: tex::TextureInfo, data: &[T])
+    fn create_texture_static<T>(&mut self, info: tex::TextureInfo, data: &[T])
                              -> Result<handle::Texture<R>, tex::TextureError> {
         let image_info = info.to_image_info();
         match self.create_texture(info) {

--- a/src/extra/factory.rs
+++ b/src/extra/factory.rs
@@ -24,7 +24,7 @@ use super::shade::*;
 pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
     /// Create a new mesh from the given vertex data.
     /// Convenience function around `create_buffer` and `Mesh::from_format`.
-    fn create_mesh<T: VertexFormat + Copy>(&mut self, data: &[T]) -> Mesh<R> {
+    fn create_mesh<T: VertexFormat>(&mut self, data: &[T]) -> Mesh<R> {
         let nv = data.len();
         //debug_assert!(nv < self.max_vertex_count); //TODO
         let buf = self.create_buffer_static(data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub use device::as_byte_slice;
 pub use device::{BufferRole, BufferInfo, BufferUsage};
 pub use device::{VertexCount, InstanceCount};
 pub use device::PrimitiveType;
+pub use device::attrib::format::{FixedPoint};
 pub use device::draw::{CommandBuffer, Gamma};
 pub use device::shade::{ProgramInfo, UniformValue};
 pub use render::{Renderer, DrawError};
@@ -63,4 +64,5 @@ pub use extra::stream::{OwnedStream, Stream};
 
 pub mod device;
 pub mod extra;
+mod macros;
 pub mod render;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,6 @@ pub use device::as_byte_slice;
 pub use device::{BufferRole, BufferInfo, BufferUsage};
 pub use device::{VertexCount, InstanceCount};
 pub use device::PrimitiveType;
-pub use device::attrib::format::{FixedPoint};
 pub use device::draw::{CommandBuffer, Gamma};
 pub use device::shade::{ProgramInfo, UniformValue};
 pub use render::{Renderer, DrawError};

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,7 +1,24 @@
+// Copyright 2014 The Gfx-rs Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Macros for deriving `VertexFormat` and `ShaderParam`.
+
 #[macro_export]
 macro_rules! gfx_vertex {
-    ($name:ident {$($field:ident: $ty:ty,)*}) => {
-        struct $name {
+    ($name:ident {$($gl_name:ident@ $field:ident: $ty:ty,)*}) => {
+        #[derive(Clone, Debug)]
+        pub struct $name {
             $($field: $ty,)*
         }
         impl $crate::VertexFormat for $name {
@@ -23,7 +40,7 @@ macro_rules! gfx_vertex {
                         instance_rate: 0,
                     };
                     attributes.push($crate::Attribute {
-                        name: String::new(), //fixme
+                        name: stringify!($gl_name).to_string(),
                         format: format,
                         buffer: buffer.raw().clone(),
                     });
@@ -36,11 +53,12 @@ macro_rules! gfx_vertex {
     }
 }
 
+#[cfg(test)]
+gfx_vertex!(_Foo {
+    x@ _x: i8,
+    y@ _y: f32,
+    z@ _z: [u32; 4],
+});
+
 #[test]
-fn vertex() {
-    gfx_vertex!(_Foo {
-        _x: i8,
-        _y: f32,
-        _z: [u32; 4],
-    });
-}
+fn vertex() {}

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,0 +1,46 @@
+#[macro_export]
+macro_rules! gfx_vertex {
+    ($name:ident {$($field:ident: $ty:ty,)*}) => {
+        struct $name {
+            $($field: $ty,)*
+        }
+        impl $crate::VertexFormat for $name {
+            fn generate<R: $crate::Resources>(buffer: &$crate::handle::Buffer<R, $name>)
+                        -> Vec<$crate::Attribute<R>> {
+                use std::mem::size_of;
+                use $crate::attrib::{Offset, Stride};
+                use $crate::attrib::format::ToFormat;
+                let stride = size_of::<$name>() as Stride;
+                let mut offset = 0 as Offset;
+                let mut attributes = Vec::new();
+                $(
+                    let (count, etype) = <$ty as ToFormat>::describe();
+                    let format = $crate::attrib::Format {
+                        elem_count: count,
+                        elem_type: etype,
+                        offset: offset,
+                        stride: stride,
+                        instance_rate: 0,
+                    };
+                    attributes.push($crate::Attribute {
+                        name: String::new(), //fixme
+                        format: format,
+                        buffer: buffer.raw().clone(),
+                    });
+                    offset += size_of::<$ty>() as Offset;
+                )*
+                assert_eq!(offset, stride as Offset);
+                attributes
+            }
+        }
+    }
+}
+
+#[test]
+fn vertex() {
+    gfx_vertex!(_Foo {
+        _x: i8,
+        _y: f32,
+        _z: [u32; 4],
+    });
+}

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -20,11 +20,8 @@
 //! create a mesh is to use the `#[vertex_format]` attribute on a struct, upload them into a
 //! `Buffer`, and then use `Mesh::from`.
 
-use device;
 use device::{PrimitiveType, Resources, VertexCount};
-use device::attrib;
-use device::handle::Buffer as BufferHandle;
-use device::handle::IndexBuffer as IndexBufferHandle;
+use device::{attrib, handle, shade};
 
 /// Describes a single attribute of a vertex buffer, including its type, name, etc.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -32,7 +29,7 @@ pub struct Attribute<R: Resources> {
     /// A name to match the shader input
     pub name: String,
     /// Vertex buffer to contain the data
-    pub buffer: device::handle::RawBuffer<R>,
+    pub buffer: handle::RawBuffer<R>,
     /// Format of the attribute
     pub format: attrib::Format,
 }
@@ -42,21 +39,21 @@ pub struct Attribute<R: Resources> {
 #[allow(missing_docs)]
 pub trait VertexFormat {
     /// Create the attributes for this type, using the given buffer.
-    fn generate<R: Resources>(buffer: device::handle::RawBuffer<R>) -> Vec<Attribute<R>>;
+    fn generate<R: Resources>(buffer: &handle::Buffer<R, Self>) -> Vec<Attribute<R>>;
 }
 
 /// Describes geometry to render.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Mesh<R: Resources> {
     /// Number of vertices in the mesh.
-    pub num_vertices: device::VertexCount,
+    pub num_vertices: VertexCount,
     /// Vertex attributes to use.
     pub attributes: Vec<Attribute<R>>,
 }
 
 impl<R: Resources> Mesh<R> {
     /// Create a new mesh, which is a `TriangleList` with no attributes and `nv` vertices.
-    pub fn new(nv: device::VertexCount) -> Mesh<R> {
+    pub fn new(nv: VertexCount) -> Mesh<R> {
         Mesh {
             num_vertices: nv,
             attributes: Vec::new(),
@@ -64,27 +61,27 @@ impl<R: Resources> Mesh<R> {
     }
 
     /// Create a new `Mesh` from a struct that implements `VertexFormat` and a buffer.
-    pub fn from_format<V: VertexFormat>(buf: BufferHandle<R, V>, nv: device::VertexCount)
+    pub fn from_format<V: VertexFormat>(buf: handle::Buffer<R, V>, nv: VertexCount)
                        -> Mesh<R> {
         Mesh {
             num_vertices: nv,
-            attributes: <V as VertexFormat>::generate(buf.raw().clone()),
+            attributes: V::generate(&buf),
         }
     }
 
     /// Create a new intanced `Mesh` given a vertex buffer and an instance buffer.
     pub fn from_format_instanced<V: VertexFormat, U: VertexFormat>(
-                                 buf: BufferHandle<R, V>,
-                                 nv: device::VertexCount,
-                                 inst: BufferHandle<R, U>) -> Mesh<R> {
-        let per_vertex   = <V as VertexFormat>::generate(buf.raw().clone());
-        let per_instance = <U as VertexFormat>::generate(inst.raw().clone());
+                                 buf: handle::Buffer<R, V>,
+                                 nv: VertexCount,
+                                 inst: handle::Buffer<R, U>) -> Mesh<R> {
+        let per_vertex   = V::generate(&buf);
+        let per_instance = U::generate(&inst);
 
         let mut attributes = per_vertex;
-        for mut at in per_instance.into_iter() {
-            at.format.instance_rate = 1;
-            attributes.push(at);
-        }
+        attributes.extend(per_instance.into_iter().map(|mut a| {
+            a.format.instance_rate = 1;
+            a
+        }));
 
         Mesh {
             num_vertices: nv,
@@ -142,11 +139,11 @@ pub enum SliceKind<R: Resources> {
     /// the vertices will be identical, wasting space for the duplicated
     /// attributes.  Instead, the `Mesh` can store 4 vertices and an
     /// `Index8` can be used instead.
-    Index8(IndexBufferHandle<R, u8>, VertexCount),
+    Index8(handle::IndexBuffer<R, u8>, VertexCount),
     /// As `Index8` but with `u16` indices
-    Index16(IndexBufferHandle<R, u16>, VertexCount),
+    Index16(handle::IndexBuffer<R, u16>, VertexCount),
     /// As `Index8` but with `u32` indices
-    Index32(IndexBufferHandle<R, u32>, VertexCount),
+    Index32(handle::IndexBuffer<R, u32>, VertexCount),
 }
 
 /// Helper methods for cleanly getting the slice of a type.
@@ -167,7 +164,7 @@ impl<R: Resources> ToSlice<R> for Mesh<R> {
     }
 }
 
-impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u8> {
+impl<R: Resources> ToSlice<R> for handle::IndexBuffer<R, u8> {
     /// Return an index slice of the whole buffer.
     fn to_slice(&self, ty: PrimitiveType) -> Slice<R> {
         Slice {
@@ -179,7 +176,7 @@ impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u8> {
     }
 }
 
-impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u16> {
+impl<R: Resources> ToSlice<R> for handle::IndexBuffer<R, u16> {
     /// Return an index slice of the whole buffer.
     fn to_slice(&self, ty: PrimitiveType) -> Slice<R> {
         Slice {
@@ -191,7 +188,7 @@ impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u16> {
     }
 }
 
-impl<R: Resources> ToSlice<R> for IndexBufferHandle<R, u32> {
+impl<R: Resources> ToSlice<R> for handle::IndexBuffer<R, u32> {
     /// Return an index slice of the whole buffer.
     fn to_slice(&self, ty: PrimitiveType) -> Slice<R> {
         Slice {
@@ -212,7 +209,7 @@ pub enum Error {
     /// A required attribute was missing.
     AttributeMissing(String),
     /// An attribute's type from the vertex format differed from the type used in the shader.
-    AttributeType(String, device::shade::BaseType),
+    AttributeType(String, shade::BaseType),
     /// An attribute index is out of supported bounds
     AttributeIndex(AttributeIndex),
     /// An input index is out of supported bounds
@@ -248,7 +245,7 @@ pub struct Link {
 impl Link {
     /// Match mesh attributes against shader inputs, produce a mesh link.
     /// Exposed to public to allow external `Batch` implementations to use it.
-    pub fn new<R: Resources>(mesh: &Mesh<R>, pinfo: &device::shade::ProgramInfo)
+    pub fn new<R: Resources>(mesh: &Mesh<R>, pinfo: &shade::ProgramInfo)
                              -> Result<Link, Error> {
         let mut indices = Vec::new();
         for sat in pinfo.attributes.iter() {


### PR DESCRIPTION
~~Hold on. I figured the `ShaderParam` implementation needs to handle unused parameters gracefully.~~
Ready to ship!

Closes #676 
Examples: https://github.com/gfx-rs/gfx_examples/pull/23
Macros: https://github.com/gfx-rs/gfx_macros/pull/18

Practically deprecates `gfx_macros`. I've lost a lot of blood writing these syntax extensions, but I'd better have a cleaner (and smaller) code base to deal with, so my vote is to let `gfx_macros` rest in peace.

Current problems (non-critical):
  - I had to add `pub` to all the generated structs and members, which prevents these to be declared inside functions
  - We have `_r: PhantomData<R>` in each shader parameter structure