### PR TITLE
Refined buffer updates code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.4.1"
+version = "0.4.2"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -19,7 +19,7 @@ macro_rules! gfx_vertex {
     ($name:ident {
         $($gl_name:ident@ $field:ident: $ty:ty,)*
     }) => {
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Copy, Debug)]
         pub struct $name {
             $(pub $field: $ty,)*
         }


### PR DESCRIPTION
Also, deriving `Copy` for vertices now. This is actually required to dynamically update them.