### PR TITLE
Make Batch trait object-safe

### DIFF
--- a/src/extra/stream.rs
+++ b/src/extra/stream.rs
@@ -20,7 +20,7 @@ use device::{Device, InstanceCount, Resources, VertexCount};
 use device::draw::CommandBuffer;
 use device::target::{ClearData, Mask, Mirror, Rect};
 use render::{DrawError, Renderer, RenderFactory};
-use render::batch::Batch;
+use render::batch::{Batch, Error};
 use render::target::Output;
 
 
@@ -74,7 +74,7 @@ pub trait Stream<R: Resources> {
 
     /// Draw a simple `Batch`.
     fn draw<B: Batch<R>>(&mut self, batch: &B) 
-            -> Result<(), DrawError<B::Error>> {
+            -> Result<(), DrawError<Error>> {
         let (ren, out) = self.access();
         ren.draw(batch, None, out)
     }
@@ -82,7 +82,7 @@ pub trait Stream<R: Resources> {
     /// Draw an instanced `Batch`.
     fn draw_instanced<B: Batch<R>>(&mut self, batch: &B,
                       count: InstanceCount, base: VertexCount)
-                      -> Result<(), DrawError<B::Error>> {
+                      -> Result<(), DrawError<Error>> {
         let (ren, out) = self.access();
         ren.draw(batch, Some((count, base)), out)
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -27,7 +27,7 @@ use device::attrib::IntSize;
 use device::draw::{Access, Gamma, Target};
 use device::draw::{CommandBuffer, DataBuffer, InstanceOption};
 use device::shade::{ProgramInfo, UniformValue};
-use render::batch::Batch;
+use render::batch::{Batch, Error};
 use render::mesh::SliceKind;
 
 /// Batches
@@ -196,7 +196,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     /// Draw a 'batch' with all known parameters specified, internal use only.
     pub fn draw<B: Batch<R>, O: target::Output<R>>(&mut self, batch: &B,
                 instances: InstanceOption, output: &O)
-                -> Result<(), DrawError<B::Error>> {
+                -> Result<(), DrawError<Error>> {
         let (mesh, attrib_iter, slice, state) = match batch.get_data() {
             Ok(data) => data,
             Err(e) => return Err(DrawError::InvalidBatch(e)),
@@ -391,7 +391,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     }
 
     fn bind_program<'a, B: Batch<R>>(&mut self, batch: &'a B)
-                    -> Result<&'a handle::Program<R>, B::Error> {
+                    -> Result<&'a handle::Program<R>, Error> {
         let program = match batch.fill_params(&mut self.parameters) {
             Ok(p) => p,
             Err(e) => return Err(e),


### PR DESCRIPTION
Breaking change!

By removing the associated error type the batch trait becomes object-safe. The advantage is, that it allows run-time dispatch of batches, as long as the backing Resources implementation is known at compile-time.

The downside is, of course, that the error type is less generic. This is deemed less useful, as it only conveys information in case of errors and the additional Error::Other enum variant allows for any kind of String to be passed as an error.

As an alternative one could implement an additional trait `DynamicBatch<R>` for all `B: Batch<R>`. This can also be done in user code. However, I think that the possibility to dynamically dispatch batches warrants this change.