### PR TITLE
Relax sized requirements in API for Batch impls

### DIFF
--- a/src/extra/stream.rs
+++ b/src/extra/stream.rs
@@ -73,14 +73,14 @@ pub trait Stream<R: Resources> {
     }
 
     /// Draw a simple `Batch`.
-    fn draw<B: Batch<R>>(&mut self, batch: &B) 
+    fn draw<B: Batch<R> + ?Sized>(&mut self, batch: &B)
             -> Result<(), DrawError<Error>> {
         let (ren, out) = self.access();
         ren.draw(batch, None, out)
     }
 
     /// Draw an instanced `Batch`.
-    fn draw_instanced<B: Batch<R>>(&mut self, batch: &B,
+    fn draw_instanced<B: Batch<R> + ?Sized>(&mut self, batch: &B,
                       count: InstanceCount, base: VertexCount)
                       -> Result<(), DrawError<Error>> {
         let (ren, out) = self.access();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -194,7 +194,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     }
 
     /// Draw a 'batch' with all known parameters specified, internal use only.
-    pub fn draw<B: Batch<R>, O: target::Output<R>>(&mut self, batch: &B,
+    pub fn draw<B: Batch<R> + ?Sized, O: target::Output<R>>(&mut self, batch: &B,
                 instances: InstanceOption, output: &O)
                 -> Result<(), DrawError<Error>> {
         let (mesh, attrib_iter, slice, state) = match batch.get_data() {
@@ -390,7 +390,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
         self.render_state.draw = *state;
     }
 
-    fn bind_program<'a, B: Batch<R>>(&mut self, batch: &'a B)
+    fn bind_program<'a, B: Batch<R> + ?Sized>(&mut self, batch: &'a B)
                     -> Result<&'a handle::Program<R>, Error> {
         let program = match batch.fill_params(&mut self.parameters) {
             Ok(p) => p,


### PR DESCRIPTION
This allows usage with trait objects, since the modified code only operates on
references to the batches anyway.