### PR TITLE
[wip] Version 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name = "gfx"
-version = "0.5.2"
+version = "0.6.0"
 description = "A high-performance, bindless graphics API"
 homepage = "https://github.com/gfx-rs/gfx-rs"
 repository = "https://github.com/gfx-rs/gfx-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,8 @@ authors = ["The Gfx-rs Developers"]
 name = "gfx"
 path = "src/lib.rs"
 
-[dependencies.draw_state]
-git = "https://github.com/gfx-rs/draw_state"
-version = "*"
-
 [dependencies]
+draw_state = "0.0.*"
 bitflags = "*"
 log = "*"
 num = "*"

--- a/src/device/draw.rs
+++ b/src/device/draw.rs
@@ -125,7 +125,7 @@ pub trait CommandBuffer<R: Resources> {
     /// Bind a single uniform in the default block
     fn bind_uniform(&mut self, shade::Location, shade::UniformValue);
     /// Bind a texture
-    fn bind_texture(&mut self, super::TextureSlot, tex::TextureKind,
+    fn bind_texture(&mut self, super::TextureSlot, tex::Kind,
                     R::Texture, Option<(R::Sampler, tex::SamplerInfo)>);
     /// Select, which color buffers are going to be targetted by the shader
     fn set_draw_color_buffers(&mut self, usize);
@@ -147,7 +147,7 @@ pub trait CommandBuffer<R: Resources> {
     /// Update a vertex/index/uniform buffer
     fn update_buffer(&mut self, R::Buffer, DataPointer, usize);
     /// Update a texture region
-    fn update_texture(&mut self, tex::TextureKind, R::Texture,
+    fn update_texture(&mut self, tex::Kind, R::Texture,
                       tex::ImageInfo, DataPointer);
     /// Clear target surfaces
     fn call_clear(&mut self, target::ClearData, target::Mask);

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -244,7 +244,7 @@ pub trait Factory<R: Resources> {
     /// Create a new texture with given data
     fn create_texture_static<T>(&mut self, info: tex::TextureInfo, data: &[T])
                              -> Result<handle::Texture<R>, tex::TextureError> {
-        let image_info = info.to_image_info();
+        let image_info = info.into();
         match self.create_texture(info) {
             Ok(handle) => self.update_texture(&handle, &image_info, data, None)
                               .map(|_| handle),

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -231,11 +231,11 @@ pub trait Factory<R: Resources> {
     /// Update the information stored in a texture
     fn update_texture_raw(&mut self, tex: &handle::Texture<R>,
                           img: &tex::ImageInfo, data: &[u8],
-                          kind: Option<tex::TextureKind>) -> Result<(), tex::TextureError>;
+                          kind: Option<tex::Kind>) -> Result<(), tex::TextureError>;
 
     fn update_texture<T>(&mut self, tex: &handle::Texture<R>,
                          img: &tex::ImageInfo, data: &[T],
-                         kind: Option<tex::TextureKind>) -> Result<(), tex::TextureError> {
+                         kind: Option<tex::Kind>) -> Result<(), tex::TextureError> {
         self.update_texture_raw(tex, img, as_byte_slice(data), kind)
     }
 

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -524,15 +524,6 @@ pub enum WrapMode {
     Clamp,
 }
 
-/// Specified how the Comparison operator should be used when sampling
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
-pub enum ComparisonMode {
-    /// the default, don't use this feature.
-    NoComparison,
-    /// Compare Reference to Texture
-    CompareRefToTexture(state::Comparison)
-}
-
 /// Specifies how to sample from a texture.
 // TODO: document the details of sampling.
 #[derive(PartialEq, PartialOrd, Clone, Copy, Debug)]
@@ -549,7 +540,7 @@ pub struct SamplerInfo {
     /// This range is used to clamp LOD level used for sampling
     pub lod_range: (f32, f32),
     /// comparison mode, used primary for a shadow map
-    pub comparison: ComparisonMode
+    pub comparison: Option<state::Comparison>,
 }
 
 impl SamplerInfo {
@@ -561,7 +552,7 @@ impl SamplerInfo {
             wrap_mode: (wrap, wrap, wrap),
             lod_bias: 0.0,
             lod_range: (-1000.0, 1000.0),
-            comparison: ComparisonMode::NoComparison
+            comparison: None,
         }
     }
 }

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -464,32 +464,6 @@ impl TextureInfo {
         Default::default()
     }
 
-    /// Convert to a default ImageInfo that could be used
-    /// to update the contents of the whole texture.
-    pub fn to_image_info(&self) -> ImageInfo {
-        ImageInfo {
-            xoffset: 0,
-            yoffset: 0,
-            zoffset: 0,
-            width: self.width,
-            height: self.height,
-            depth: self.depth,
-            format: self.format,
-            mipmap: 0,
-        }
-    }
-
-    /// Convert to a `SurfaceInfo`, used as a common denominator between
-    /// surfaces and textures.
-    pub fn to_surface_info(&self) -> SurfaceInfo {
-        SurfaceInfo {
-            width: self.width,
-            height: self.height,
-            format: self.format,
-            aa_mode: self.kind.get_aa_mode(),
-        }
-    }
-
     /// Check if given ImageInfo is a part of the texture.
     pub fn contains(&self, img: &ImageInfo) -> bool {
         self.width <= img.xoffset + img.width &&
@@ -498,6 +472,32 @@ impl TextureInfo {
         self.format == img.format &&
         img.mipmap < self.levels &&
         self.kind.get_aa_mode().is_none()
+    }
+}
+
+impl From<TextureInfo> for ImageInfo {
+    fn from(ti: TextureInfo) -> ImageInfo {
+        ImageInfo {
+            xoffset: 0,
+            yoffset: 0,
+            zoffset: 0,
+            width: ti.width,
+            height: ti.height,
+            depth: ti.depth,
+            format: ti.format,
+            mipmap: 0,
+        }
+    }
+}
+
+impl From<TextureInfo> for SurfaceInfo {
+    fn from(ti: TextureInfo) -> SurfaceInfo {
+        SurfaceInfo {
+            width: ti.width,
+            height: ti.height,
+            format: ti.format,
+            aa_mode: ti.kind.get_aa_mode(),
+        }
     }
 }
 

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -116,6 +116,18 @@ pub enum Components {
     RGBA,
 }
 
+impl Components {
+    /// Get the number of components.
+    pub fn get_count(&self) -> u8 {
+        match *self {
+            Components::R    => 1,
+            Components::RG   => 2,
+            Components::RGB  => 3,
+            Components::RGBA => 4,
+        }
+    }
+}
+
 /// Codec used to compress image data.
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
 #[allow(non_camel_case_types)]
@@ -252,6 +264,33 @@ impl Format {
             Format::Compressed(Compression::ETC2_SRGB) => true,
             _ => false,
         }
+    }
+
+    /// Get size of the texel in bytes.
+    pub fn get_size(&self) -> Option<u8> {
+        Some(match *self {
+            Format::Float(c, FloatSize::F16) => c.get_count() * 2,
+            Format::Float(c, FloatSize::F32) => c.get_count() * 4,
+            Format::Float(c, FloatSize::F64) => c.get_count() * 8,
+            Format::Integer(c, bits, _) => (c.get_count() * bits) >> 3,
+            Format::Unsigned(c, bits, _) => (c.get_count() * bits) >> 3,
+            Format::Compressed(_) => return None,
+            Format::R3_G3_B2 => 1,
+            Format::R5_G6_B5 => 2,
+            Format::RGB5_A1 => 2,
+            Format::RGB10_A2 => 4,
+            Format::RGB10_A2UI => 4,
+            Format::R11F_G11F_B10F => 4,
+            Format::RGB9_E5 => 4,
+            Format::BGRA8 => 4,
+            Format::SRGB8 => 4,
+            Format::SRGB8_A8 => 4,
+            Format::DEPTH16 => 2,
+            Format::DEPTH24 => 4,
+            Format::DEPTH32F => 4,
+            Format::DEPTH24_STENCIL8 => 4,
+            Format::DEPTH32F_STENCIL8 => 8,
+        })
     }
 }
 
@@ -465,6 +504,12 @@ impl TextureInfo {
 impl ImageInfo {
     /// Create a new `ImageInfo`, using default values.
     pub fn new() -> ImageInfo { Default::default() }
+    /// Get the total number of texels.
+    pub fn get_texel_count(&self) -> usize {
+        self.width as usize *
+        self.height as usize *
+        self.depth as usize
+    }
 }
 
 /// Specifies how texture coordinates outside the range `[0, 1]` are handled.

--- a/src/device/tex.rs
+++ b/src/device/tex.rs
@@ -120,7 +120,7 @@ impl Components {
     /// Get the number of components.
     pub fn get_count(&self) -> u8 {
         match *self {
-            Components::R    => 1,
+            Components::R     => 1,
             Components::RG   => 2,
             Components::RGB  => 3,
             Components::RGBA => 4,
@@ -339,37 +339,6 @@ pub enum FilterMethod {
     Anisotropic(u8)
 }
 
-/// Specifies how a given texture may be used. The available texture types are
-/// restricted by what Metal exposes, though this could conceivably be
-/// extended in the future. Note that a single texture can *only* ever be of
-/// one kind. A texture created as `Texture2D` will forever be `Texture2D`.
-// TODO: "Texture views" let you get around that limitation.
-#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
-pub enum TextureKind {
-    /// A single row of texels.
-    Texture1D,
-    /// An array of rows of texels. Equivalent to Texture2D except that texels
-    /// in a different row are not sampled.
-    Texture1DArray,
-    /// A traditional 2D texture, with rows arranged contiguously.
-    Texture2D,
-    /// An array of 2D textures. Equivalent to Texture3D except that texels in
-    /// a different depth level are not sampled.
-    Texture2DArray,
-    /// A multi-sampled 2D texture. Each pixel may have more than one data value
-    /// (sample) associated with it.
-    Texture2DMultiSample(AaMode),
-    /// A array of multi-sampled 2D textures.
-    Texture2DMultiSampleArray(AaMode),
-    /// A set of 6 2D textures, one for each face of a cube.
-    ///
-    /// When creating a cube texture, the face is ignored, and storage for all 6 faces is created.
-    /// When updating, only the face specified is updated.
-    TextureCube(CubeFace),
-    /// A volume texture, with each 2D layer arranged contiguously.
-    Texture3D,
-}
-
 /// The face of a cube texture to do an operation on.
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
 #[allow(missing_docs)]
@@ -382,12 +351,43 @@ pub enum CubeFace {
     NegY
 }
 
-impl TextureKind {
+/// Specifies how a given texture may be used. The available texture types are
+/// restricted by what Metal exposes, though this could conceivably be
+/// extended in the future. Note that a single texture can *only* ever be of
+/// one kind. A texture created as `Texture2D` will forever be `Texture2D`.
+// TODO: "Texture views" let you get around that limitation.
+#[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Copy, Clone, Debug)]
+pub enum Kind {
+    /// A single row of texels.
+    D1,
+    /// An array of rows of texels. Equivalent to Texture2D except that texels
+    /// in a different row are not sampled.
+    D1Array,
+    /// A traditional 2D texture, with rows arranged contiguously.
+    D2,
+    /// An array of 2D textures. Equivalent to Texture3D except that texels in
+    /// a different depth level are not sampled.
+    D2Array,
+    /// A multi-sampled 2D texture. Each pixel may have more than one data value
+    /// (sample) associated with it.
+    D2MultiSample(AaMode),
+    /// A array of multi-sampled 2D textures.
+    D2MultiSampleArray(AaMode),
+    /// A set of 6 2D textures, one for each face of a cube.
+    ///
+    /// When creating a cube texture, the face is ignored, and storage for all 6 faces is created.
+    /// When updating, only the face specified is updated.
+    Cube(CubeFace),
+    /// A volume texture, with each 2D layer arranged contiguously.
+    D3,
+}
+
+impl Kind {
     /// Return the anti-aliasing mode of the texture
     pub fn get_aa_mode(&self) -> Option<AaMode> {
         match *self {
-            TextureKind::Texture2DMultiSample(aa) => Some(aa),
-            TextureKind::Texture2DMultiSampleArray(aa) => Some(aa),
+            Kind::D2MultiSample(aa) => Some(aa),
+            Kind::D2MultiSampleArray(aa) => Some(aa),
             _ => None,
         }
     }
@@ -410,7 +410,7 @@ pub struct TextureInfo {
     /// by the shader. width and height of each consecutive mipmap level is
     /// halved, starting from level 0.
     pub levels: u8,
-    pub kind: TextureKind,
+    pub kind: Kind,
     pub format: Format,
 }
 
@@ -452,7 +452,7 @@ impl Default for TextureInfo {
             height: 1,
             depth: 1,
             levels: !0,
-            kind: TextureKind::Texture2D,
+            kind: Kind::D2,
             format: RGBA8,
         }
     }

--- a/src/extra/factory.rs
+++ b/src/extra/factory.rs
@@ -81,7 +81,7 @@ pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
             height: height,
             depth: 1,
             levels: 1,
-            kind: tex::TextureKind::Texture2D,
+            kind: tex::Kind::D2,
             format: tex::RGBA8,
         })
     }
@@ -94,7 +94,7 @@ pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
             height: height,
             depth: 1,
             levels: 99,
-            kind: tex::TextureKind::Texture2D,
+            kind: tex::Kind::D2,
             format: tex::RGBA8,
         };
         match self.create_texture_static(info, data) {
@@ -114,7 +114,7 @@ pub trait FactoryExt<R: device::Resources>: device::Factory<R> {
             height: height,
             depth: 0,
             levels: 1,
-            kind: tex::TextureKind::Texture2D,
+            kind: tex::Kind::D2,
             format: tex::Format::DEPTH24_STENCIL8,
         })
     }

--- a/src/extra/stream.rs
+++ b/src/extra/stream.rs
@@ -19,7 +19,7 @@
 use device::{Device, InstanceCount, Resources, VertexCount};
 use device::draw::CommandBuffer;
 use device::target::{ClearData, Mask, Mirror, Rect};
-use render::{DrawError, Renderer, RenderFactory};
+use render::{BlitError, DrawError, Renderer, RenderFactory};
 use render::batch::{Batch, Error};
 use render::target::Output;
 
@@ -59,17 +59,21 @@ pub trait Stream<R: Resources> {
     /// Blit on this stream from another `Output`.
     fn blit_on<I: Output<R>>(&mut self,
                source: &I, source_rect: Rect, dest_rect: Rect,
-               mirror: Mirror, mask: Mask) {
+               mirror: Mirror, mask: Mask)
+               -> Result<(), BlitError>
+    {
         let (ren, out) = self.access();
-        ren.blit(source, source_rect, out, dest_rect, mirror, mask);
+        ren.blit(source, source_rect, out, dest_rect, mirror, mask)
     }
 
     /// Blit this stream to another `Output`.
     fn blit_to<O: Output<R>>(&mut self,
                destination: &O, dest_rect: Rect, source_rect: Rect,
-               mirror: Mirror, mask: Mask) {
+               mirror: Mirror, mask: Mask)
+               -> Result<(), BlitError>
+    {
         let (ren, out) = self.access();
-        ren.blit(out, source_rect, destination, dest_rect, mirror, mask);
+        ren.blit(out, source_rect, destination, dest_rect, mirror, mask)
     }
 
     /// Draw a simple `Batch`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use device::{VertexCount, InstanceCount};
 pub use device::PrimitiveType;
 pub use device::draw::{CommandBuffer, Gamma, InstanceOption};
 pub use device::shade::{ProgramInfo, UniformValue};
-pub use render::{Renderer, DrawError};
+pub use render::{Renderer, BlitError, DrawError, UpdateError};
 pub use render::batch;
 pub use render::mesh::{Attribute, Mesh, VertexFormat};
 pub use render::mesh::Error as MeshError;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -68,7 +68,7 @@ macro_rules! gfx_parameters {
 
         impl<R: $crate::Resources> $crate::shade::ShaderParam for $name<R> {
             type Resources = R;
-            type Link = ($(Option<$crate::shade::ParameterId>, ::std::marker::PhantomData<$ty>,)*);
+            type Link = ($((Option<$crate::shade::ParameterId>, ::std::marker::PhantomData<$ty>),)*);
 
             fn create_link(_: Option<&$name<R>>, info: &$crate::ProgramInfo)
                            -> Result<Self::Link, $crate::shade::ParameterError>
@@ -119,12 +119,12 @@ macro_rules! gfx_parameters {
                         _ => return Err($crate::shade::ParameterError::MissingBlock(t.name.clone()))
                     }
                 }
-                Ok(( $($field, ::std::marker::PhantomData,)* ))
+                Ok(( $(($field, ::std::marker::PhantomData),)* ))
             }
 
             fn fill_params(&self, link: &Self::Link, storage: &mut $crate::ParamStorage<R>) {
                 use $crate::shade::Parameter;
-                let &($($field, _,)*) = link;
+                let &($(($field, _),)*) = link;
                 $(
                     if let Some(id) = $field {
                         self.$field.put(id, storage);

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -17,9 +17,6 @@
 //! `RefBatch` and `OwnedBatch` implementations.
 
 use std::fmt;
-use std::cmp::Ordering;
-use std::marker::PhantomData;
-use std::ops::Deref;
 use draw_state::DrawState;
 
 use device::{Resources, PrimitiveType};

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -16,7 +16,6 @@
 //! except for the target frame. Here we define the `Batch` trait as well as
 //! `RefBatch` and `OwnedBatch` implementations.
 
-use std::fmt;
 use draw_state::DrawState;
 
 use device::{Resources, PrimitiveType};
@@ -132,7 +131,7 @@ impl<T: ShaderParam> Full<T> {
 }
 
 impl<T: ShaderParam> Batch<T::Resources> for Full<T> {
-    fn get_data(&self) -> Result<BatchData<T::Resources>, ()> {
+    fn get_data(&self) -> Result<BatchData<T::Resources>, Error> {
         Ok((&self.mesh, self.mesh_link.to_iter(), &self.slice, &self.state))
     }
 
@@ -194,13 +193,13 @@ impl<T: ShaderParam> Core<T> {
 }
 
 impl<'a, T: ShaderParam + 'a> Batch<T::Resources> for Complete<'a, T> {
-    fn get_data(&self) -> Result<BatchData<T::Resources>, ()> {
+    fn get_data(&self) -> Result<BatchData<T::Resources>, Error> {
         let (b, slice, _, state) = *self;
         Ok((&b.mesh, b.mesh_link.to_iter(), slice, state))
     }
 
     fn fill_params(&self, values: &mut ParamStorage<T::Resources>)
-                   -> Result<&ProgramHandle<T::Resources>, ()> {
+                   -> Result<&ProgramHandle<T::Resources>, Error> {
         let (b, _, data, _) = *self;
         values.reserve(b.program.get_info());
         data.fill_params(&b.param_link, values);

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -36,8 +36,6 @@ pub enum Error {
     Mesh(mesh::Error),
     /// Error connecting shader parameters
     Parameters(ParameterError),
-    /// Error context is full
-    ContextFull,
     /// Another kind of error
     Other(String),
 }
@@ -56,7 +54,7 @@ pub trait Batch<R: Resources> {
 
 /// A batch that is constructed on the fly when rendering.
 /// Meant to be a struct, blocked by #614
-pub type ImplicitBatch<'a, T: ShaderParam> = (
+pub type Implicit<'a, T: ShaderParam> = (
     &'a mesh::Mesh<T::Resources>,
     mesh::Slice<T::Resources>,
     &'a ProgramHandle<T::Resources>,
@@ -69,11 +67,11 @@ pub fn bind<'a, T: ShaderParam>(draw_state: &'a DrawState,
              mesh: &'a mesh::Mesh<T::Resources>,
              slice: mesh::Slice<T::Resources>,
              program: &'a ProgramHandle<T::Resources>,
-             data: &'a T) -> ImplicitBatch<'a, T> {
+             data: &'a T) -> Implicit<'a, T> {
     (mesh, slice, program, data, draw_state)
 }
 
-impl<'a, T: ShaderParam> Batch<T::Resources> for ImplicitBatch<'a, T> {
+impl<'a, T: ShaderParam> Batch<T::Resources> for Implicit<'a, T> {
     fn get_data(&self) -> Result<BatchData<T::Resources>, Error> {
         let (mesh, ref slice, program, _, state) = *self;
         match mesh::Link::new(mesh, program.get_info()) {
@@ -96,9 +94,9 @@ impl<'a, T: ShaderParam> Batch<T::Resources> for ImplicitBatch<'a, T> {
     }
 }
 
-/// Owned batch - self-contained, but has heap-allocated data
+/// Full batch - contains everything needed for rendering.
 #[derive(Clone)]
-pub struct OwnedBatch<T: ShaderParam> {
+pub struct Full<T: ShaderParam> {
     mesh: mesh::Mesh<T::Resources>,
     mesh_link: mesh::Link,
     /// Mesh slice
@@ -111,20 +109,20 @@ pub struct OwnedBatch<T: ShaderParam> {
     pub state: DrawState,
 }
 
-impl<T: ShaderParam> OwnedBatch<T> {
-    /// Create a new owned batch
+impl<T: ShaderParam> Full<T> {
+    /// Create a new full batch
     pub fn new(mesh: mesh::Mesh<T::Resources>, program: ProgramHandle<T::Resources>, param: T)
-           -> Result<OwnedBatch<T>, Error> {
+           -> Result<Full<T>, Error> {
         let slice = mesh.to_slice(PrimitiveType::TriangleList);
         let mesh_link = match mesh::Link::new(&mesh, program.get_info()) {
             Ok(l) => l,
             Err(e) => return Err(Error::Mesh(e)),
         };
-        let param_link = match ShaderParam::create_link(None::<&T>, program.get_info()) {
+        let param_link = match ShaderParam::create_link(Some(&param), program.get_info()) {
             Ok(l) => l,
             Err(e) => return Err(Error::Parameters(e)),
         };
-        Ok(OwnedBatch {
+        Ok(Full {
             mesh: mesh,
             mesh_link: mesh_link,
             slice: slice,
@@ -136,8 +134,8 @@ impl<T: ShaderParam> OwnedBatch<T> {
     }
 }
 
-impl<T: ShaderParam> Batch<T::Resources> for OwnedBatch<T> {
-    fn get_data(&self) -> Result<BatchData<T::Resources>, Error> {
+impl<T: ShaderParam> Batch<T::Resources> for Full<T> {
+    fn get_data(&self) -> Result<BatchData<T::Resources>, ()> {
         Ok((&self.mesh, self.mesh_link.to_iter(), &self.slice, &self.state))
     }
 
@@ -149,373 +147,66 @@ impl<T: ShaderParam> Batch<T::Resources> for OwnedBatch<T> {
     }
 }
 
-type Index = u16;
 
-//#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
-struct Id<T>(Index, PhantomData<T>);
-
-impl<T> Copy for Id<T> {}
-
-impl<T> Clone for Id<T> {
-    fn clone(&self) -> Id<T> { *self }
-}
-
-impl<T> Id<T> {
-    fn unwrap(&self) -> Index {
-        let Id(i, _) = *self;
-        i
-    }
-}
-
-impl<T> fmt::Debug for Id<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Id(i, _) = *self;
-        write!(f, "Id({})", i)
-    }
-}
-
-impl<T> PartialEq for Id<T> {
-    fn eq(&self, other: &Id<T>) -> bool {
-        self.unwrap() == other.unwrap()
-    }
-}
-
-impl<T> Eq for Id<T> {}
-
-impl<T> PartialOrd for Id<T> {
-    fn partial_cmp(&self, other: &Id<T>) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T> Ord for Id<T> {
-    fn cmp(&self, other: &Id<T>) -> Ordering {
-        self.unwrap().cmp(&other.unwrap())
-    }
-}
-
-struct Array<T> {
-    data: Vec<T>,
-    //generation: u16,
-}
-
-/// Error accessing outside of the array
-#[derive(Debug)]
-pub struct OutOfBounds(pub usize);
-
-impl<T> Array<T> {
-    fn new() -> Array<T> {
-        Array {
-            data: Vec::new(),
-            //generation: 0,
-        }
-    }
-
-    fn get(&self, id: Id<T>) -> Result<&T, OutOfBounds> {
-        let Id(i, _) = id;
-        if (i as usize) < self.data.len() {
-            Ok(&self.data[i as usize])
-        }else {
-            Err(OutOfBounds(i as usize))
-        }
-    }
-}
-
-impl<T: Clone + PartialEq> Array<T> {
-    fn find_or_insert(&mut self, value: &T) -> Option<Id<T>> {
-        use num::traits::FromPrimitive;
-        match self.data.iter().position(|v| v == value) {
-            Some(i) => FromPrimitive::from_u32(i as u32)
-                .map(|id| Id(id, PhantomData)),
-            None => {
-                FromPrimitive::from_u32(self.data.len() as u32).map(|id| {
-                    self.data.push(value.clone());
-                    Id(id, PhantomData)
-                })
-            },
-        }
-    }
-}
-
-
-/// Referenced core - a minimal sealed batch that depends on `Context`.
-/// It has references to the resources (mesh, program, state), that are held
-/// by the context that created the batch, so these have to be used together.
-pub struct CoreBatch<T: ShaderParam> {
-    mesh_id: Id<mesh::Mesh<T::Resources>>,
+/// Core batch - a minimal sealed batch.
+#[derive(Clone)]
+pub struct Core<T: ShaderParam> {
+    mesh: mesh::Mesh<T::Resources>,
     mesh_link: mesh::Link,
-    program_id: Id<ProgramHandle<T::Resources>>,
+    program: ProgramHandle<T::Resources>,
     param_link: T::Link,
-    state_id: Id<DrawState>,
 }
 
-impl<T: ShaderParam> Copy for CoreBatch<T> where T::Link: Copy {}
-
-impl<T: ShaderParam> Clone for CoreBatch<T> where T::Link: Clone {
-    fn clone(&self) -> CoreBatch<T> {
-        CoreBatch {
-            mesh_id: self.mesh_id,
-            mesh_link: self.mesh_link,
-            program_id: self.program_id,
-            param_link: self.param_link.clone(),
-            state_id: self.state_id,
-        }
-    }
-}
-
-impl<T: ShaderParam> fmt::Debug for CoreBatch<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "CoreBatch(mesh: {:?}, program: {:?}, state: {:?})",
-            self.mesh_id, self.program_id, self.state_id)
-    }
-}
-
-impl<T: ShaderParam> PartialEq for CoreBatch<T> {
-    fn eq(&self, other: &CoreBatch<T>) -> bool {
-        self.program_id == other.program_id &&
-        self.state_id == other.state_id &&
-        self.mesh_id == other.mesh_id
-    }
-}
-
-impl<T: ShaderParam> Eq for CoreBatch<T> {}
-
-impl<T: ShaderParam> PartialOrd for CoreBatch<T> {
-    fn partial_cmp(&self, other: &CoreBatch<T>) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: ShaderParam> Ord for CoreBatch<T> {
-    fn cmp(&self, other: &CoreBatch<T>) -> Ordering {
-        (&self.program_id, &self.state_id, &self.mesh_id).cmp(
-        &(&other.program_id, &other.state_id, &other.mesh_id))
-    }
-}
-
-impl<T: ShaderParam> CoreBatch<T> {
-    /// Compare meshes by Id
-    pub fn cmp_mesh(&self, other: &CoreBatch<T>) -> Ordering {
-        self.mesh_id.cmp(&other.mesh_id)
-    }
-    /// Compare programs by Id
-    pub fn cmp_program(&self, other: &CoreBatch<T>) -> Ordering {
-        self.program_id.cmp(&other.program_id)
-    }
-    /// Compare draw states by Id
-    pub fn cmp_state(&self, other: &CoreBatch<T>) -> Ordering {
-        self.state_id.cmp(&other.state_id)
-    }
-}
-
-/// A `CoreBatch` completed by a slice, shader parameters, and a context
+/// A `Core` completed by a mesh slice, shader parameters, and a state.
 /// Implements `Batch` thus can be drawn.
 /// It is meant to be a struct, but we have lots of lifetime issues
 /// with associated resources, binding which looks nasty (#614)
-pub type CoreBatchFull<'a, T: ShaderParam> = (
-    &'a CoreBatch<T>,
+pub type Complete<'a, T: ShaderParam> = (
+    &'a Core<T>,
     &'a mesh::Slice<T::Resources>,
     &'a T,
-    &'a Context<T::Resources>
+    &'a DrawState
 );
 
-
-/// An expanded version of the `CoreBatch`, carrying the parameters and
-/// the mesh slice with it, publicly mutable.
-pub struct RefBatch<T: ShaderParam> {
-    /// Core of the batch
-    pub core: CoreBatch<T>,
-    /// Mesh slice
-    pub slice: mesh::Slice<T::Resources>,
-    /// Shader parameter values
-    pub params: T,
-}
-
-impl<T: ShaderParam> Deref for RefBatch<T> {
-    type Target = CoreBatch<T>;
-
-    fn deref(&self) -> &CoreBatch<T> {
-        &self.core
-    }
-}
-
-impl<T: ShaderParam + Clone> Clone for RefBatch<T> where T::Link: Copy {
-    fn clone(&self) -> RefBatch<T> {
-        RefBatch {
-            core: self.core,
-            slice: self.slice.clone(),
-            params: self.params.clone(),
-        }
-    }
-}
-
-impl<T: ShaderParam + fmt::Debug> fmt::Debug for RefBatch<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RefBatch(core: {:?}, slice: {:?}, params: {:?}",
-            self.core, self.slice, self.params)
-    }
-}
-
-
-/// Factory of ref batches, required to always be used with them.
-pub struct Context<R: Resources> {
-    meshes: Array<mesh::Mesh<R>>,
-    programs: Array<ProgramHandle<R>>,
-    states: Array<DrawState>,
-}
-
-/// A `RefBatch` completed by the a batch context
-/// Implements `Batch` thus can be drawn.
-/// It is meant to be a struct, but we have lots of lifetime issues
-/// with associated resources, binding which looks nasty (#614)
-pub type RefBatchFull<'a, T: ShaderParam> = (
-    &'a RefBatch<T>,
-    &'a Context<T::Resources>
-);
-
-impl<R: Resources> Context<R> {
-    /// Create a new empty `Context`
-    pub fn new() -> Context<R> {
-        Context {
-            meshes: Array::new(),
-            programs: Array::new(),
-            states: Array::new(),
-        }
-    }
-}
-
-impl<R: Resources> Context<R> {
-    fn make<T: ShaderParam<Resources = R>>(&mut self,
-            program: &ProgramHandle<R>,
-            params: Option<&T>,
-            mesh: &mesh::Mesh<R>,
-            state: &DrawState)
-            -> Result<CoreBatch<T>, Error> {
-        let mesh_link = match mesh::Link::new(mesh, program.get_info()) {
+impl<T: ShaderParam> Core<T> {
+    /// Create a new core batch.
+    pub fn new(mesh: mesh::Mesh<T::Resources>, program: ProgramHandle<T::Resources>)
+           -> Result<Core<T>, Error> {
+        let mesh_link = match mesh::Link::new(&mesh, program.get_info()) {
             Ok(l) => l,
             Err(e) => return Err(Error::Mesh(e)),
         };
-        let link = match ShaderParam::create_link(params, program.get_info()) {
+        let param_link = match ShaderParam::create_link(None::<&T>, program.get_info()) {
             Ok(l) => l,
-            Err(e) => return Err(Error::Parameters(e))
+            Err(e) => return Err(Error::Parameters(e)),
         };
-        let mesh_id = match self.meshes.find_or_insert(mesh) {
-            Some(id) => id,
-            None => return Err(Error::ContextFull),
-        };
-        let program_id = match self.programs.find_or_insert(program) {
-            Some(id) => id,
-            None => return Err(Error::ContextFull),
-        };
-        let state_id = match self.states.find_or_insert(state) {
-            Some(id) => id,
-            None => return Err(Error::ContextFull),
-        };
-
-        Ok(CoreBatch {
-            mesh_id: mesh_id,
+        Ok(Core {
+            mesh: mesh,
             mesh_link: mesh_link,
-            program_id: program_id,
-            param_link: link,
-            state_id: state_id,
+            program: program,
+            param_link: param_link,
         })
     }
 
-    /// Produce a new `CoreBatch`
-    pub fn make_core<T: ShaderParam<Resources = R>>(&mut self,
-                     program: &ProgramHandle<R>,
-                     mesh: &mesh::Mesh<R>,
-                     state: &DrawState)
-                     -> Result<CoreBatch<T>, Error> {
-        self.make(program, None, mesh, state)
-    }
-
-    /// Produce a new `RefBatch`
-    pub fn make_batch<T: ShaderParam<Resources = R>>(&mut self,
-                      program: &ProgramHandle<R>,
-                      params: T,
-                      mesh: &mesh::Mesh<R>,
-                      slice: mesh::Slice<R>,
-                      state: &DrawState)
-                      -> Result<RefBatch<T>, Error> {
-        self.make(program, Some(&params), mesh, state)
-            .map(|core| RefBatch {
-            core: core,
-            slice: slice,
-            params: params,
-        })
-    }
-
-    /// Complete a CoreBatch temporarily by turning it into CoreBatchFull
-    pub fn bind<'a, T: ShaderParam<Resources = R> + 'a>(&'a self,
-                 core: &'a CoreBatch<T>, slice: &'a mesh::Slice<R>,
-                 params: &'a T) -> CoreBatchFull<'a, T> {
-        (core, slice, params, self)
-    }
-
-    /// Get data from a batch in the format required for `Batch`
-    pub fn get_data<'a, T: ShaderParam<Resources = R> + 'a>(&'a self,
-                    core: &CoreBatch<T>, slice: &'a mesh::Slice<R>)
-                    -> Result<BatchData<'a, T::Resources>, OutOfBounds> {
-        Ok((try!(self.meshes.get(core.mesh_id)),
-            core.mesh_link.to_iter(),
-            slice,
-            try!(self.states.get(core.state_id))
-        ))
+    /// Add missing components to complete the batch for rendering.
+    pub fn with<'a>(&'a self, slice: &'a mesh::Slice<T::Resources>,
+                params: &'a T, state: &'a DrawState)
+                -> Complete<'a, T> {
+        (self, slice, params, state)
     }
 }
 
-impl<'a, T: ShaderParam + 'a> Batch<T::Resources> for CoreBatchFull<'a, T> {
-    fn get_data(&self) -> Result<BatchData<T::Resources>, Error> {
-        let (b, slice, _, ctx) = *self;
-        ctx.get_data(b, slice)
-            .map_err(|err| Error::Other(format!("{:?}", err)))
+impl<'a, T: ShaderParam + 'a> Batch<T::Resources> for Complete<'a, T> {
+    fn get_data(&self) -> Result<BatchData<T::Resources>, ()> {
+        let (b, slice, _, state) = *self;
+        Ok((&b.mesh, b.mesh_link.to_iter(), slice, state))
     }
 
     fn fill_params(&self, values: &mut ParamStorage<T::Resources>)
-                   -> Result<&ProgramHandle<T::Resources>, Error> {
-        let (b, _, data, ctx) = *self;
-        ctx.programs.get(b.program_id)
-            .map(|program| {
-                values.reserve(program.get_info());
-                data.fill_params(&b.param_link, values);
-                program
-            })
-            .map_err(|err| Error::Other(format!("{:?}", err)))
-    }
-}
-
-impl<'a, T: ShaderParam + 'a> Batch<T::Resources> for RefBatchFull<'a, T> {
-    fn get_data(&self) -> Result<BatchData<T::Resources>, Error> {
-        let (b, ctx) = *self;
-        ctx.get_data(&b.core, &b.slice)
-            .map_err(|err| Error::Other(format!("{:?}", err)))
-    }
-
-    fn fill_params(&self, values: &mut ParamStorage<T::Resources>)
-                   -> Result<&ProgramHandle<T::Resources>, Error> {
-        let (b, ctx) = *self;
-        ctx.programs.get(b.core.program_id)
-            .map(|program| {
-                values.reserve(program.get_info());
-                b.params.fill_params(&b.core.param_link, values);
-                program
-            })
-            .map_err(|err| Error::Other(format!("{:?}", err)))
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use device::Resources;
-    use super::Batch;
-
-    #[test]
-    fn batch_is_object_safe() {
-        #[allow(dead_code)]
-        fn must_compile<B, R>(b: &B) -> &Batch<R>
-            where B: Batch<R> + 'static,
-                  R: Resources,
-        { b as &Batch<R> }
+                   -> Result<&ProgramHandle<T::Resources>, ()> {
+        let (b, _, data, _) = *self;
+        values.reserve(b.program.get_info());
+        data.fill_params(&b.param_link, values);
+        Ok(&b.program)
     }
 }

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -98,7 +98,7 @@ pub struct Full<T: ShaderParam> {
     /// Mesh slice
     pub slice: mesh::Slice<T::Resources>,
     /// Parameter data.
-    pub param: T,
+    pub params: T,
     program: ProgramHandle<T::Resources>,
     param_link: T::Link,
     /// Draw state
@@ -107,14 +107,14 @@ pub struct Full<T: ShaderParam> {
 
 impl<T: ShaderParam> Full<T> {
     /// Create a new full batch
-    pub fn new(mesh: mesh::Mesh<T::Resources>, program: ProgramHandle<T::Resources>, param: T)
+    pub fn new(mesh: mesh::Mesh<T::Resources>, program: ProgramHandle<T::Resources>, params: T)
            -> Result<Full<T>, Error> {
         let slice = mesh.to_slice(PrimitiveType::TriangleList);
         let mesh_link = match mesh::Link::new(&mesh, program.get_info()) {
             Ok(l) => l,
             Err(e) => return Err(Error::Mesh(e)),
         };
-        let param_link = match ShaderParam::create_link(Some(&param), program.get_info()) {
+        let param_link = match ShaderParam::create_link(Some(&params), program.get_info()) {
             Ok(l) => l,
             Err(e) => return Err(Error::Parameters(e)),
         };
@@ -123,7 +123,7 @@ impl<T: ShaderParam> Full<T> {
             mesh_link: mesh_link,
             slice: slice,
             program: program,
-            param: param,
+            params: params,
             param_link: param_link,
             state: DrawState::new(),
         })
@@ -138,7 +138,7 @@ impl<T: ShaderParam> Batch<T::Resources> for Full<T> {
     fn fill_params(&self, values: &mut ParamStorage<T::Resources>)
                    -> Result<&ProgramHandle<T::Resources>, Error> {
         values.reserve(self.program.get_info());
-        self.param.fill_params(&self.param_link, values);
+        self.params.fill_params(&self.param_link, values);
         Ok(&self.program)
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -224,7 +224,7 @@ impl<R: Resources, C: CommandBuffer<R>> Renderer<R, C> {
     /// Draw a 'batch' with all known parameters specified, internal use only.
     pub fn draw<B: Batch<R> + ?Sized, O: target::Output<R>>(&mut self, batch: &B,
                 instances: InstanceOption, output: &O)
-                -> Result<(), DrawError<B::Error>>
+                -> Result<(), DrawError<Error>>
     {
         let (mesh, attrib_iter, slice, state) = match batch.get_data() {
             Ok(data) => data,

--- a/src/render/shade.rs
+++ b/src/render/shade.rs
@@ -123,7 +123,7 @@ impl<R: Resources> Parameter<R> for TextureParam<R> {
 pub trait ShaderParam {
     type Resources: Resources;
     /// A helper structure to contain variable indices inside the shader
-    type Link;
+    type Link: Clone;
     /// Create a new link to be used with a given program
     fn create_link(Option<&Self>, &shade::ProgramInfo) -> Result<Self::Link, ParameterError>;
     /// Get all the contained parameter values, using a given link
@@ -174,6 +174,7 @@ pub struct ParamDictionary<R: Resources> {
 }
 
 /// Redirects program input to the relevant ParamDictionary cell
+#[derive(Clone)]
 pub struct ParamDictionaryLink {
     uniforms: Vec<usize>,
     blocks: Vec<usize>,

--- a/src/render/target.rs
+++ b/src/render/target.rs
@@ -36,7 +36,7 @@ impl<R: Resources> Plane<R> {
     pub fn get_surface_info(&self) -> device::tex::SurfaceInfo {
         match *self {
             Plane::Surface(ref suf) => *suf.get_info(),
-            Plane::Texture(ref tex, _, _) => tex.get_info().to_surface_info(),
+            Plane::Texture(ref tex, _, _) => (*tex.get_info()).into(),
         }
     }
 


### PR DESCRIPTION
Closes #745 
Has all the changes from 0.6 branch, merged with upstream.
GL device: https://github.com/gfx-rs/gfx_device_gl/pull/42
Glutin window: https://github.com/gfx-rs/gfx_window_glutin/pull/13
GLFW window: https://github.com/gfx-rs/gfx_window_glfw/pull/8
Examples: https://github.com/gfx-rs/gfx_examples/pull/30

Major changes:
  - now using crates.io internally for dependencies. Users are encouraged to also use it, we may not guarantee any stability in the Git tree.
  - batch context is removed as well as all the relevant batch types. Please use `batch::Core` or `batch::Full`.
  - texture kinds enum is totally [changed](https://github.com/kvark/gfx-rs/commit/5f97904cef73432c56c54265f16c57128041ec00)
  - `Renderer::update_*` calls now error out instead of panicking
  - `gfx_device_gl::Factory` implements `Clone` instead of `gfx_device_gl::Device::spawn_factory`